### PR TITLE
Fix target path for css-properties.json

### DIFF
--- a/style/properties/build.py
+++ b/style/properties/build.py
@@ -121,7 +121,7 @@ def main():
             as_json = json.dumps(properties_dict, indent=4, sort_keys=True)
 
             # Five dotdots: /path/to/servo(5)/target(4)/debug(3)/build(2)/style-*(1)/out
-            doc_servo = os.path.join(OUT_DIR, "..", "..", "..", "..", "..", "target", "doc", "servo")
+            doc_servo = os.path.join(OUT_DIR, "..", "..", "..", "..", "..", "target", "doc", "stylo")
 
             write(doc_servo, "css-properties.html", as_html)
             write(doc_servo, "css-properties.json", as_json)

--- a/style/properties/build.py
+++ b/style/properties/build.py
@@ -119,7 +119,10 @@ def main():
                 os.path.join(BASE, "properties.html.mako"), properties=properties_dict
             )
             as_json = json.dumps(properties_dict, indent=4, sort_keys=True)
-            doc_servo = os.path.join(BASE, "..", "..", "..", "target", "doc", "servo")
+
+            # Five dotdots: /path/to/servo(5)/target(4)/debug(3)/build(2)/style-*(1)/out
+            doc_servo = os.path.join(OUT_DIR, "..", "..", "..", "..", "..", "target", "doc", "servo")
+
             write(doc_servo, "css-properties.html", as_html)
             write(doc_servo, "css-properties.json", as_json)
             write(OUT_DIR, "css-properties.json", as_json)


### PR DESCRIPTION
Servo’s style unit tests ([tests/unit/style/properties/scaffolding.rs](https://github.com/servo/servo/blob/ef8a0b7f7be8dce5a09f771822c112692a0f9921/tests/unit/style/properties/scaffolding.rs)) rely on a css-properties.json in target/doc/servo, but now that Stylo is in its own repo, we write the file to the wrong path. This patch fixes that.

- Before patch, single repo:
  /path/to/servo/components/style/properties/../../../target/doc/servo
  = /path/to/servo/target/doc/servo
- Before patch, separate Stylo repo:
  /path/two/stylo/style/properties/../../../target/doc/servo
  = /path/two/target/doc/servo
- After patch, separate Stylo repo:
  /path/to/servo/target/debug/build/style-\*/out/../../../../../target/doc/servo
  = /path/to/servo/target/doc/servo