### PR TITLE
Fix target path for css-properties.json again

### DIFF
--- a/style/properties/build.py
+++ b/style/properties/build.py
@@ -120,8 +120,10 @@ def main():
             )
             as_json = json.dumps(properties_dict, indent=4, sort_keys=True)
 
-            # Five dotdots: /path/to/servo(5)/target(4)/debug(3)/build(2)/style-*(1)/out
-            doc_servo = os.path.join(OUT_DIR, "..", "..", "..", "..", "..", "target", "doc", "stylo")
+            # Four dotdots: /path/to/target(4)/debug(3)/build(2)/style-*(1)/out
+            # Do not ascend above the target dir, because it may not be called target
+            # or even have a parent (see CARGO_TARGET_DIR).
+            doc_servo = os.path.join(OUT_DIR, "..", "..", "..", "..", "doc", "stylo")
 
             write(doc_servo, "css-properties.html", as_html)
             write(doc_servo, "css-properties.json", as_json)


### PR DESCRIPTION
Servo’s Windows builds use CARGO_TARGET_DIR to put build artifacts on another disk, outside the main repo. The ability to override the target directory means we can’t necessarily traverse from there to ../target. This patch fixes that.