### PR TITLE
Enable `font-variant` for Layout 2020 (was #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
  "phf 0.10.1",
- "phf_codegen",
+ "phf_codegen 0.10.0",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -772,13 +772,13 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -910,6 +910,16 @@ checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -1133,8 +1143,8 @@ dependencies = [
  "fxhash",
  "log",
  "new_debug_unreachable",
- "phf 0.10.1",
- "phf_codegen",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
  "precomputed-hash",
  "servo_arc",
  "size_of_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1318,7 @@ dependencies = [
  "log",
  "malloc_size_of",
  "malloc_size_of_derive",
+ "matches",
  "mime",
  "mozbuild",
  "new_debug_unreachable",

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -43,6 +43,7 @@ lazy_static = "1"
 log = { version = "0.4", features = ["std"] }
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
+matches = "0.1"
 mime = "0.3.13"
 new_debug_unreachable = "1.0"
 num-derive = "0.4"

--- a/style/lib.rs
+++ b/style/lib.rs
@@ -50,6 +50,9 @@ extern crate log;
 extern crate malloc_size_of;
 #[macro_use]
 extern crate malloc_size_of_derive;
+#[allow(unused_extern_crates)]
+#[macro_use]
+extern crate matches;
 #[cfg(feature = "gecko")]
 pub use nsstring;
 #[cfg(feature = "gecko")]

--- a/style/properties/shorthands/font.mako.rs
+++ b/style/properties/shorthands/font.mako.rs
@@ -326,7 +326,6 @@
 
 <%helpers:shorthand name="font-variant"
                     engines="gecko servo"
-                    servo_pref="layout.legacy_layout",
                     flags="SHORTHAND_IN_GETCS"
                     sub_properties="font-variant-caps
                                     ${'font-variant-alternates' if engine == 'gecko' else ''}

--- a/style/properties_and_values/registry.rs
+++ b/style/properties_and_values/registry.rs
@@ -25,6 +25,7 @@ pub struct PropertyRegistration {
 /// The script registry of custom properties.
 /// <https://drafts.css-houdini.org/css-properties-values-api-1/#dom-window-registeredpropertyset-slot>
 #[derive(Default)]
+#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
 pub struct ScriptRegistry {
     properties: PrecomputedHashMap<Atom, PropertyRegistration>,
 }

--- a/style/stylesheets/page_rule.rs
+++ b/style/stylesheets/page_rule.rs
@@ -83,7 +83,7 @@ bitflags! {
     /// page-rule applies.
     ///
     /// https://drafts.csswg.org/css-page-3/#page-selectors
-    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "gecko", derive(Clone, Copy))]
     #[repr(C)]
     pub struct PagePseudoClassFlags : u8 {
         /// No pseudo-classes
@@ -218,7 +218,7 @@ impl Parse for PageSelector {
         _context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Self, ParseError<'i>> {
-        let name = input.try_parse(parse_page_name).unwrap_or(AtomIdent(atom!("")));
+        let name = input.try_parse(parse_page_name).unwrap_or(AtomIdent::new(atom!("")));
         let mut pseudos = PagePseudoClasses::default();
         while let Ok(pc) = input.try_parse(PagePseudoClass::parse) {
             pseudos.push(pc);

--- a/style/stylist.rs
+++ b/style/stylist.rs
@@ -35,10 +35,10 @@ use crate::stylesheets::layer_rule::{LayerName, LayerOrder};
 #[cfg(feature = "gecko")]
 use crate::stylesheets::{
     CounterStyleRule, FontFaceRule, FontFeatureValuesRule, FontPaletteValuesRule,
+    PagePseudoClassFlags,
 };
 use crate::stylesheets::{
     CssRule, EffectiveRulesIterator, Origin, OriginSet, PageRule, PerOrigin, PerOriginIter,
-    PagePseudoClassFlags, PageRule,
 };
 use crate::stylesheets::{StyleRule, StylesheetContents, StylesheetInDocument};
 use crate::AllocErr;

--- a/style/stylist.rs
+++ b/style/stylist.rs
@@ -1586,7 +1586,6 @@ impl<T: 'static> LayerOrderedMap<T> {
     fn clear(&mut self) {
         self.0.clear();
     }
-    #[cfg(feature = "gecko")]
     fn try_insert(&mut self, name: Atom, v: T, id: LayerId) -> Result<(), AllocErr> {
         self.try_insert_with(name, v, id, |_, _| Ordering::Equal)
     }
@@ -1610,7 +1609,6 @@ impl<T: 'static> LayerOrderedMap<T> {
         vec.push((v, id));
         Ok(())
     }
-    #[cfg(feature = "gecko")]
     fn sort(&mut self, layers: &[CascadeLayer]) {
         self.sort_with(layers, |_, _| Ordering::Equal)
     }

--- a/style/values/generics/basic_shape.rs
+++ b/style/values/generics/basic_shape.rs
@@ -362,7 +362,6 @@ pub struct PolygonCoord<LengthPercentage>(pub LengthPercentage, pub LengthPercen
 // https://www.w3.org/TR/SVG/painting.html#FillRuleProperty
 // says that it can also be `inherit`
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,

--- a/style/values/generics/calc.rs
+++ b/style/values/generics/calc.rs
@@ -217,7 +217,7 @@ bitflags! {
     /// This is used as a hint for the parser to fast-reject invalid
     /// expressions. Numbers are always allowed because they multiply other
     /// units.
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[cfg_attr(feature = "gecko", derive(Clone, Copy, PartialEq, Eq))]
     pub struct CalcUnits: u8 {
         /// <length>
         const LENGTH = 1 << 0;

--- a/style/values/generics/color.rs
+++ b/style/values/generics/color.rs
@@ -25,7 +25,8 @@ pub enum GenericColor<Percentage> {
 
 bitflags! {
     /// Flags used to modify the calculation of a color mix result.
-    #[derive(Clone, Copy, Default, MallocSizeOf, PartialEq, ToShmem)]
+    #[derive(Default, MallocSizeOf, ToShmem)]
+    #[cfg_attr(feature = "gecko", derive(Clone, Copy, PartialEq))]
     #[repr(C)]
     pub struct ColorMixFlags : u8 {
         /// Normalize the weights of the mix.

--- a/style/values/generics/mod.rs
+++ b/style/values/generics/mod.rs
@@ -160,7 +160,6 @@ impl SpecifiedValueInfo for CounterStyle {
 }
 
 /// A wrapper of Non-negative values.
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,

--- a/style/values/specified/basic_shape.rs
+++ b/style/values/specified/basic_shape.rs
@@ -142,7 +142,7 @@ bitflags! {
     /// we use the bitflags to choose the supported basic shapes for each property at the parse
     /// time.
     /// https://github.com/w3c/csswg-drafts/issues/7390
-    #[derive(Clone, Copy)]
+    #[cfg_attr(feature = "gecko", derive(Clone, Copy))]
     #[repr(C)]
     pub struct AllowedBasicShapes: u8 {
         /// inset().

--- a/style/values/specified/text.rs
+++ b/style/values/specified/text.rs
@@ -341,6 +341,7 @@ impl Parse for TextTransform {
                 "capitalize" if result.case_ == TextTransformCase::None => {
                     result.case_ = TextTransformCase::Capitalize
                 },
+                #[cfg(feature = "gecko")]
                 "math-auto" if result.case_ == TextTransformCase::None &&
                     result.other_.is_empty() => {
                     result.case_ = TextTransformCase::MathAuto;
@@ -411,6 +412,7 @@ pub enum TextTransformCase {
     /// Capitalize each word.
     Capitalize,
     /// Automatic italicization of math variables.
+    #[cfg(feature = "gecko")]
     MathAuto,
 }
 

--- a/style_config/lib.rs
+++ b/style_config/lib.rs
@@ -69,7 +69,7 @@ pub fn set_i32(key: &str, value: i32) {
 
 #[test]
 fn test() {
-    let mut prefs = Preferences::default();
+    let prefs = Preferences::default();
 
     // Prefs have default values when unset.
     assert_eq!(prefs.get_bool("foo"), false);

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -93,6 +93,9 @@ macro_rules! pref {
     ("layout.css.motion-path-basic-shapes.enabled") => {
         false
     };
+    ("layout.css.motion-path-coord-box.enabled") => {
+        false
+    };
     ("layout.css.motion-path-ray.enabled") => {
         false
     };

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -90,6 +90,9 @@ macro_rules! pref {
     ("layout.css.motion-path-offset-position.enabled") => {
         false
     };
+    ("layout.css.motion-path-basic-shapes.enabled") => {
+        false
+    };
     ("layout.css.motion-path-ray.enabled") => {
         false
     };

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -63,6 +63,9 @@ macro_rules! pref {
     ("layout.css.forced-colors.enabled") => {
         false
     };
+    ("layout.css.gradient-color-interpolation-method.enabled") => {
+        false
+    };
     ("layout.css.grid-template-masonry-value.enabled") => {
         false
     };

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -21,6 +21,9 @@ macro_rules! pref {
     ("gfx.font_rendering.opentype_svg.enabled") => {
         false
     };
+    ("layout.css.abs-sign.enabled") => {
+        true
+    };
     ("layout.css.basic-shape-xywh.enabled") => {
         true
     };

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -21,6 +21,9 @@ macro_rules! pref {
     ("gfx.font_rendering.opentype_svg.enabled") => {
         false
     };
+    ("layout.css.basic-shape-xywh.enabled") => {
+        true
+    };
     ("layout.css.color-mix.enabled") => {
         true
     };


### PR DESCRIPTION
This patch relands #4 into the new upgrade branch, pending discussion in #5.