### PR TITLE
Run the sync upstream workflow daily (and rename it)

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,4 +1,4 @@
-name: Sync
+name: Sync upstream with mozilla-central
 
 on:
   schedule:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,8 +1,8 @@
 name: Sync
 
 on:
-  # schedule:
-  #   - cron: '0 13 * * *'
+  schedule:
+    - cron: '0 13 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This patch makes the sync upstream workflow run daily, and gives it a clearer name that will distinguish it from a future workflow that syncs main into a date branch.