### PR TITLE
Remove Servo-specific font code and expose font-face properties

### DIFF
--- a/style/font_face.rs
+++ b/style/font_face.rs
@@ -8,23 +8,18 @@
 
 use crate::error_reporting::ContextualParseError;
 use crate::parser::{Parse, ParserContext};
-#[cfg(feature = "gecko")]
 use crate::properties::longhands::font_language_override;
 use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
 use crate::str::CssStringWriter;
 use crate::values::computed::font::{FamilyName, FontStretch};
 use crate::values::generics::font::FontStyle as GenericFontStyle;
-#[cfg(feature = "gecko")]
 use crate::values::specified::font::MetricsOverride;
 use crate::values::specified::font::SpecifiedFontStyle;
 use crate::values::specified::font::{AbsoluteFontWeight, FontStretch as SpecifiedFontStretch};
-#[cfg(feature = "gecko")]
 use crate::values::specified::font::{FontFeatureSettings, FontVariationSettings};
 use crate::values::specified::url::SpecifiedUrl;
 use crate::values::specified::Angle;
-#[cfg(feature = "gecko")]
 use crate::values::specified::NonNegativePercentage;
-#[cfg(feature = "gecko")]
 use cssparser::UnicodeRange;
 use cssparser::{
     AtRuleParser, CowRcStr, DeclarationParser, Parser, QualifiedRuleParser, RuleBodyItemParser,
@@ -490,64 +485,6 @@ pub fn parse_font_face_block(
 #[cfg(feature = "servo")]
 pub struct FontFace<'a>(&'a FontFaceRuleData);
 
-/// A list of effective sources that we send over through IPC to the font cache.
-#[cfg(feature = "servo")]
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
-pub struct EffectiveSources(Vec<Source>);
-
-#[cfg(feature = "servo")]
-impl<'a> FontFace<'a> {
-    /// Returns the list of effective sources for that font-face, that is the
-    /// sources which don't list any format hint, or the ones which list at
-    /// least "truetype" or "opentype".
-    pub fn effective_sources(&self) -> EffectiveSources {
-        EffectiveSources(
-            self.sources()
-                .0
-                .iter()
-                .rev()
-                .filter(|source| {
-                    if let Source::Url(ref url_source) = **source {
-                        // We support only opentype fonts and truetype is an alias for
-                        // that format. Sources without format hints need to be
-                        // downloaded in case we support them.
-                        url_source
-                            .format_hint
-                            .as_ref()
-                            .map_or(true, |hint| match hint {
-                                FontFaceSourceFormat::Keyword(
-                                    FontFaceSourceFormatKeyword::Truetype
-                                    | FontFaceSourceFormatKeyword::Opentype
-                                    | FontFaceSourceFormatKeyword::Woff,
-                                ) => true,
-                                FontFaceSourceFormat::String(s) => {
-                                    s == "truetype" || s == "opentype" || s == "woff"
-                                }
-                                _ => false,
-                            })
-                    } else {
-                        true
-                    }
-                })
-                .cloned()
-                .collect(),
-        )
-    }
-}
-
-#[cfg(feature = "servo")]
-impl Iterator for EffectiveSources {
-    type Item = Source;
-    fn next(&mut self) -> Option<Source> {
-        self.0.pop()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.0.len(), Some(self.0.len()))
-    }
-}
-
 struct FontFaceRuleParser<'a, 'b: 'a> {
     context: &'a ParserContext<'b>,
     rule: &'a mut FontFaceRuleData,
@@ -773,7 +710,6 @@ macro_rules! font_face_descriptors {
     }
 }
 
-#[cfg(feature = "gecko")]
 font_face_descriptors! {
     mandatory descriptors = [
         /// The name of this font face
@@ -818,18 +754,5 @@ font_face_descriptors! {
 
         /// The size adjustment for this font face.
         "size-adjust" size_adjust / mSizeAdjust: NonNegativePercentage,
-    ]
-}
-
-#[cfg(feature = "servo")]
-font_face_descriptors! {
-    mandatory descriptors = [
-        /// The name of this font face
-        "font-family" family / mFamily: FamilyName,
-
-        /// The alternative sources for this font face.
-        "src" sources / mSrc: SourceList,
-    ]
-    optional descriptors = [
     ]
 }

--- a/style/properties/longhands/font.mako.rs
+++ b/style/properties/longhands/font.mako.rs
@@ -222,7 +222,7 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "font-language-override",
     "FontLanguageOverride",
-    engines="gecko",
+    engines="gecko servo",
     initial_value="computed::FontLanguageOverride::normal()",
     initial_specified_value="specified::FontLanguageOverride::normal()",
     animation_value_type="discrete",

--- a/style/values/computed/font.rs
+++ b/style/values/computed/font.rs
@@ -868,6 +868,7 @@ where
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 #[value_info(other_values = "normal")]
 pub struct FontLanguageOverride(pub u32);

--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -51,6 +51,12 @@ macro_rules! pref {
     ("layout.css.fit-content-function.enabled") => {
         false
     };
+    ("layout.css.font-display.enabled") => {
+        false
+    };
+    ("layout.css.font-metrics-overrides.enabled") => {
+        false
+    };
     ("layout.css.font-palette.enabled") => {
         false
     };


### PR DESCRIPTION
Servo needs these properties in order to properly load the fonts on
servo.org. In addition, remove some custom Servo code that is no longer
necessary. Servo will handle filtering web font sources internally,
which will allow it to be less dependent on Stylo for this.

This is the first step toward WOFF2 support in Servo.
