### PR TITLE
Enable conic gradient parsing for servo

### DIFF
--- a/style/values/specified/image.rs
+++ b/style/values/specified/image.rs
@@ -984,7 +984,7 @@ impl Gradient {
             AngleOrPercentage::parse_with_unitless,
         )?;
 
-        if cfg!(feature = "servo") || items.len() < 2 {
+        if items.len() < 2 {
             return Err(input.new_custom_error(StyleParseErrorKind::UnspecifiedError));
         }
 


### PR DESCRIPTION
This was disabled in a pretty sneaky way. Servo can easily render
these with WebRender, so enable them.
