### PR TITLE
Enable x-lang attribute for Servo engine

### DIFF
--- a/style/properties/longhands/font.mako.rs
+++ b/style/properties/longhands/font.mako.rs
@@ -291,7 +291,7 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "-x-lang",
     "XLang",
-    engines="gecko",
+    engines="gecko servo",
     initial_value="computed::XLang::get_initial_value()",
     animation_value_type="none",
     enabled_in="",

--- a/style/values/specified/font.rs
+++ b/style/values/specified/font.rs
@@ -2007,6 +2007,8 @@ impl XTextScale {
     ToCss,
     ToResolvedValue,
     ToShmem,
+    Serialize,
+    Deserialize,
 )]
 /// Internal property that reflects the lang attribute
 pub struct XLang(#[css(skip)] pub Atom);

--- a/style/values/specified/font.rs
+++ b/style/values/specified/font.rs
@@ -2007,9 +2007,8 @@ impl XTextScale {
     ToCss,
     ToResolvedValue,
     ToShmem,
-    Serialize,
-    Deserialize,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 /// Internal property that reflects the lang attribute
 pub struct XLang(#[css(skip)] pub Atom);
 


### PR DESCRIPTION
### Description

This Pull Request includes the following changes:

#### `style/properties/longhands/font.mako.rs`
- Modified the `helpers.predefined_type` function call for `-x-lang`, adding support for `gecko servo` engines.

#### `style/values/specified/font.rs`
- Added implementation for `XTextScale`, providing functionality for handling text scaling.

refer at [servo issue](https://github.com/servo/servo/issues/31723)