### PR TITLE
Reland "Bug 1842221 - Simplify ThinArc and friends"

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -19,7 +19,7 @@ use cssparser::{BasicParseError, BasicParseErrorKind, ParseError, ParseErrorKind
 use cssparser::{CowRcStr, Delimiter, SourceLocation};
 use cssparser::{Parser as CssParser, ToCss, Token};
 use precomputed_hash::PrecomputedHash;
-use servo_arc::{Arc, HeaderWithLength, ThinArc, UniqueArc};
+use servo_arc::{Arc, ThinArc, UniqueArc};
 use smallvec::SmallVec;
 use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Debug};
@@ -677,7 +677,7 @@ pub struct Selector<Impl: SelectorImpl>(
 impl<Impl: SelectorImpl> Selector<Impl> {
     /// See Arc::mark_as_intentionally_leaked
     pub fn mark_as_intentionally_leaked(&self) {
-        self.0.with_arc(|a| a.mark_as_intentionally_leaked())
+        self.0.mark_as_intentionally_leaked()
     }
 
     fn ampersand() -> Self {
@@ -692,32 +692,32 @@ impl<Impl: SelectorImpl> Selector<Impl> {
 
     #[inline]
     pub fn specificity(&self) -> u32 {
-        self.0.header.header.specificity()
+        self.0.header.specificity()
     }
 
     #[inline]
     fn flags(&self) -> SelectorFlags {
-        self.0.header.header.flags
+        self.0.header.flags
     }
 
     #[inline]
     pub fn has_pseudo_element(&self) -> bool {
-        self.0.header.header.has_pseudo_element()
+        self.0.header.has_pseudo_element()
     }
 
     #[inline]
     pub fn has_parent_selector(&self) -> bool {
-        self.0.header.header.has_parent_selector()
+        self.0.header.has_parent_selector()
     }
 
     #[inline]
     pub fn is_slotted(&self) -> bool {
-        self.0.header.header.is_slotted()
+        self.0.header.is_slotted()
     }
 
     #[inline]
     pub fn is_part(&self) -> bool {
-        self.0.header.header.is_part()
+        self.0.header.is_part()
     }
 
     #[inline]
@@ -807,7 +807,7 @@ impl<Impl: SelectorImpl> Selector<Impl> {
         }
 
         SelectorIter {
-            iter: self.0.slice[..self.len() - 2].iter(),
+            iter: self.0.slice()[..self.len() - 2].iter(),
             next_combinator: None,
         }
     }
@@ -839,7 +839,7 @@ impl<Impl: SelectorImpl> Selector<Impl> {
     /// skipping the rightmost |offset| Components.
     #[inline]
     pub fn iter_from(&self, offset: usize) -> SelectorIter<Impl> {
-        let iter = self.0.slice[offset..].iter();
+        let iter = self.0.slice()[offset..].iter();
         SelectorIter {
             iter,
             next_combinator: None,
@@ -850,7 +850,7 @@ impl<Impl: SelectorImpl> Selector<Impl> {
     /// or panics if the component is not a combinator.
     #[inline]
     pub fn combinator_at_match_order(&self, index: usize) -> Combinator {
-        match self.0.slice[index] {
+        match self.0.slice()[index] {
             Component::Combinator(c) => c,
             ref other => panic!(
                 "Not a combinator: {:?}, {:?}, index: {}",
@@ -863,14 +863,14 @@ impl<Impl: SelectorImpl> Selector<Impl> {
     /// combinators, in matching order (from right to left).
     #[inline]
     pub fn iter_raw_match_order(&self) -> slice::Iter<Component<Impl>> {
-        self.0.slice.iter()
+        self.0.slice().iter()
     }
 
     /// Returns the combinator at index `index` (zero-indexed from the left),
     /// or panics if the component is not a combinator.
     #[inline]
     pub fn combinator_at_parse_order(&self, index: usize) -> Combinator {
-        match self.0.slice[self.len() - index - 1] {
+        match self.0.slice()[self.len() - index - 1] {
             Component::Combinator(c) => c,
             ref other => panic!(
                 "Not a combinator: {:?}, {:?}, index: {}",
@@ -884,7 +884,7 @@ impl<Impl: SelectorImpl> Selector<Impl> {
     /// `offset`.
     #[inline]
     pub fn iter_raw_parse_order_from(&self, offset: usize) -> Rev<slice::Iter<Component<Impl>>> {
-        self.0.slice[..self.len() - offset].iter().rev()
+        self.0.slice()[..self.len() - offset].iter().rev()
     }
 
     /// Creates a Selector from a vec of Components, specified in parse order. Used in tests.
@@ -1015,8 +1015,7 @@ impl<Impl: SelectorImpl> Selector<Impl> {
                 .chain(std::iter::once(Component::Is(
                     parent.clone()
                 )));
-            let header = HeaderWithLength::new(specificity_and_flags, len);
-            UniqueArc::from_header_and_iter_with_size(header, iter, len)
+            UniqueArc::from_header_and_iter_with_size(specificity_and_flags, iter, len)
         } else {
             let iter = self.iter_raw_match_order().map(|component| {
                 use self::Component::*;
@@ -1105,17 +1104,16 @@ impl<Impl: SelectorImpl> Selector<Impl> {
                     )),
                 }
             });
-            let header = HeaderWithLength::new(specificity_and_flags, iter.len());
-            UniqueArc::from_header_and_iter(header, iter)
+            UniqueArc::from_header_and_iter(specificity_and_flags, iter)
         };
         items.header_mut().specificity = specificity.into();
-        Selector(items.shareable_thin())
+        Selector(items.shareable())
     }
 
     /// Returns count of simple selectors and combinators in the Selector.
     #[inline]
     pub fn len(&self) -> usize {
-        self.0.slice.len()
+        self.0.len()
     }
 
     /// Returns the address on the heap of the ThinArc for memory reporting.
@@ -1573,13 +1571,13 @@ impl<Impl: SelectorImpl> NthOfSelectorData<Impl> {
     /// Returns the An+B part of the selector
     #[inline]
     pub fn nth_data(&self) -> &NthSelectorData {
-        &self.0.header.header
+        &self.0.header
     }
 
     /// Returns the selector list part of the selector
     #[inline]
     pub fn selectors(&self) -> &[Selector<Impl>] {
-        &self.0.slice
+        self.0.slice()
     }
 }
 

--- a/servo_arc/Cargo.toml
+++ b/servo_arc/Cargo.toml
@@ -12,7 +12,8 @@ path = "lib.rs"
 
 [features]
 gecko_refcount_logging = []
-servo = ["serde"]
+servo = ["serde", "track_alloc_size"]
+track_alloc_size = []
 
 [dependencies]
 nodrop = { version = "0.1.8" }

--- a/servo_arc/lib.rs
+++ b/servo_arc/lib.rs
@@ -672,7 +672,7 @@ impl<H: PartialEq, T: PartialEq> PartialEq for HeaderSlice<H, T> {
 impl<H, T> Drop for HeaderSlice<H, T> {
     fn drop(&mut self) {
         unsafe {
-            let mut ptr = self.data.as_mut_ptr();
+            let mut ptr = self.data_mut();
             for _ in 0..self.len {
                 std::ptr::drop_in_place(ptr);
                 ptr = ptr.offset(1);
@@ -880,18 +880,6 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
 pub type ThinArc<H, T> = Arc<HeaderSlice<H, T>>;
 
 impl<H, T> UniqueArc<HeaderSlice<H, T>> {
-    /// Returns the dynamically sized slice in this HeaderSlice.
-    #[inline(always)]
-    pub fn slice(&self) -> &[T] {
-        &self.slice
-    }
-
-    /// Returns the len of the slice.
-    #[inline(always)]
-    pub fn len(&self) -> usize {
-        self.slice.len()
-    }
-
     #[inline]
     pub fn from_header_and_iter<I>(header: H, items: I) -> Self
     where

--- a/servo_arc/lib.rs
+++ b/servo_arc/lib.rs
@@ -122,6 +122,8 @@ impl<T> UniqueArc<T> {
                 .unwrap_or_else(|| alloc::handle_alloc_error(layout))
                 .cast::<ArcInner<mem::MaybeUninit<T>>>();
             ptr::write(&mut p.as_mut().count, atomic::AtomicUsize::new(1));
+            #[cfg(feature = "track_alloc_size")]
+            ptr::write(&mut p.as_mut().alloc_size, layout.size());
 
             #[cfg(feature = "gecko_refcount_logging")]
             {
@@ -171,9 +173,24 @@ unsafe impl<T: ?Sized + Sync + Send> Send for Arc<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> {}
 
 /// The object allocated by an Arc<T>
+///
+/// See https://github.com/mozilla/cbindgen/issues/937 for the derive-{eq,neq}=false. But we don't
+/// use those anyways so we can just disable them.
+/// cbindgen:derive-eq=false
+/// cbindgen:derive-neq=false
 #[repr(C)]
 struct ArcInner<T: ?Sized> {
     count: atomic::AtomicUsize,
+    // NOTE(emilio): This needs to be here so that HeaderSlice<> is deallocated properly if the
+    // allocator relies on getting the right Layout. We don't need to track the right alignment,
+    // since we know that statically.
+    //
+    // This member could be completely avoided once min_specialization feature is stable (by
+    // implementing a trait for HeaderSlice that gives you the right layout). For now, servo-only
+    // since Gecko doesn't need it (its allocator doesn't need the size for the alignments we care
+    // about). See https://github.com/rust-lang/rust/issues/31844.
+    #[cfg(feature = "track_alloc_size")]
+    alloc_size: usize,
     data: T,
 }
 
@@ -192,24 +209,31 @@ impl<T> Arc<T> {
     /// Construct an `Arc<T>`
     #[inline]
     pub fn new(data: T) -> Self {
-        let ptr = Box::into_raw(Box::new(ArcInner {
-            count: atomic::AtomicUsize::new(1),
-            data,
-        }));
+        let layout = Layout::new::<ArcInner<T>>();
+        let p = unsafe {
+            let ptr = ptr::NonNull::new(alloc::alloc(layout))
+                .unwrap_or_else(|| alloc::handle_alloc_error(layout))
+                .cast::<ArcInner<T>>();
+            ptr::write(ptr.as_ptr(), ArcInner {
+                count: atomic::AtomicUsize::new(1),
+                #[cfg(feature = "track_alloc_size")]
+                alloc_size: layout.size(),
+                data,
+            });
+            ptr
+        };
 
         #[cfg(feature = "gecko_refcount_logging")]
         unsafe {
             // FIXME(emilio): Would be so amazing to have
             // std::intrinsics::type_name() around, so that we could also report
             // a real size.
-            NS_LogCtor(ptr as *mut _, b"ServoArc\0".as_ptr() as *const _, 8);
+            NS_LogCtor(p.as_ptr() as *mut _, b"ServoArc\0".as_ptr() as *const _, 8);
         }
 
-        unsafe {
-            Arc {
-                p: ptr::NonNull::new_unchecked(ptr),
-                phantom: PhantomData,
-            }
+        Arc {
+            p,
+            phantom: PhantomData,
         }
     }
 
@@ -266,10 +290,13 @@ impl<T> Arc<T> {
     where
         F: FnOnce(Layout) -> *mut u8,
     {
-        let ptr = alloc(Layout::new::<ArcInner<T>>()) as *mut ArcInner<T>;
+        let layout = Layout::new::<ArcInner<T>>();
+        let ptr = alloc(layout) as *mut ArcInner<T>;
 
         let x = ArcInner {
             count: atomic::AtomicUsize::new(STATIC_REFCOUNT),
+            #[cfg(feature = "track_alloc_size")]
+            alloc_size: layout.size(),
             data,
         };
 
@@ -337,7 +364,14 @@ impl<T: ?Sized> Arc<T> {
     #[inline(never)]
     unsafe fn drop_slow(&mut self) {
         self.record_drop();
-        let _ = Box::from_raw(self.ptr());
+        let inner = self.ptr();
+
+        let layout = Layout::for_value(&*inner);
+        #[cfg(feature = "track_alloc_size")]
+        let layout = Layout::from_size_align_unchecked((*inner).alloc_size, layout.align());
+
+        std::ptr::drop_in_place(inner);
+        alloc::dealloc(inner as *mut _, layout);
     }
 
     /// Test pointer equality between the two Arcs, i.e. they must be the _same_
@@ -711,11 +745,6 @@ impl<H, T> HeaderSlice<H, T> {
     }
 }
 
-#[inline(always)]
-fn divide_rounding_up(dividend: usize, divisor: usize) -> usize {
-    (dividend + divisor - 1) / divisor
-}
-
 impl<H, T> Arc<HeaderSlice<H, T>> {
     /// Creates an Arc for a HeaderSlice using the given header struct and
     /// iterator to generate the slice.
@@ -742,26 +771,17 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
     {
         assert_ne!(size_of::<T>(), 0, "Need to think about ZST");
 
-        let size = size_of::<ArcInner<HeaderSlice<H, T>>>() + size_of::<T>() * num_items;
-        let inner_align = align_of::<ArcInner<HeaderSlice<H, T>>>();
-        debug_assert!(inner_align >= align_of::<T>());
-
-        let ptr: *mut ArcInner<HeaderSlice<H, T>>;
-        unsafe {
+        let layout = Layout::new::<ArcInner<HeaderSlice<H, T>>>();
+        debug_assert!(layout.align() >= align_of::<T>());
+        debug_assert!(layout.align() >= align_of::<usize>());
+        let array_layout = Layout::array::<T>(num_items).expect("Overflow");
+        let (layout, _offset) = layout.extend(array_layout).expect("Overflow");
+        let p = unsafe {
             // Allocate the buffer.
-            let layout = if inner_align <= align_of::<usize>() {
-                Layout::from_size_align_unchecked(size, align_of::<usize>())
-            } else if inner_align <= align_of::<u64>() {
-                // On 32-bit platforms <T> may have 8 byte alignment while usize
-                // has 4 byte aligment.  Use u64 to avoid over-alignment.
-                // This branch will compile away in optimized builds.
-                Layout::from_size_align_unchecked(size, align_of::<u64>())
-            } else {
-                panic!("Over-aligned type not handled");
-            };
-
             let buffer = alloc(layout);
-            ptr = buffer as *mut ArcInner<HeaderSlice<H, T>>;
+            let mut p = ptr::NonNull::new(buffer)
+                .unwrap_or_else(|| alloc::handle_alloc_error(layout))
+                .cast::<ArcInner<HeaderSlice<H, T>>>();
 
             // Write the data.
             //
@@ -772,11 +792,13 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
             } else {
                 atomic::AtomicUsize::new(1)
             };
-            ptr::write(&mut ((*ptr).count), count);
-            ptr::write(&mut ((*ptr).data.header), header);
-            ptr::write(&mut ((*ptr).data.len), num_items);
+            ptr::write(&mut p.as_mut().count, count);
+            #[cfg(feature = "track_alloc_size")]
+            ptr::write(&mut p.as_mut().alloc_size, layout.size());
+            ptr::write(&mut p.as_mut().data.header, header);
+            ptr::write(&mut p.as_mut().data.len, num_items);
             if num_items != 0 {
-                let mut current = std::ptr::addr_of_mut!((*ptr).data.data) as *mut T;
+                let mut current = std::ptr::addr_of_mut!(p.as_mut().data.data) as *mut T;
                 for _ in 0..num_items {
                     ptr::write(
                         current,
@@ -789,20 +811,21 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
                 // We should have consumed the buffer exactly, maybe accounting
                 // for some padding from the alignment.
                 debug_assert!(
-                    (buffer.add(size) as usize - current as *mut u8 as usize) < inner_align
+                    (buffer.add(layout.size()) as usize - current as *mut u8 as usize) < layout.align()
                 );
             }
             assert!(
                 items.next().is_none(),
                 "ExactSizeIterator under-reported length"
             );
-        }
+            p
+        };
         #[cfg(feature = "gecko_refcount_logging")]
         unsafe {
             if !is_static {
                 // FIXME(emilio): Would be so amazing to have
                 // std::intrinsics::type_name() around.
-                NS_LogCtor(ptr as *mut _, b"ServoArc\0".as_ptr() as *const _, 8)
+                NS_LogCtor(p.as_ptr() as *mut _, b"ServoArc\0".as_ptr() as *const _, 8)
             }
         }
 
@@ -812,11 +835,10 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
             size_of::<usize>(),
             "The Arc should be thin"
         );
-        unsafe {
-            Arc {
-                p: ptr::NonNull::new_unchecked(ptr),
-                phantom: PhantomData,
-            }
+
+        Arc {
+            p,
+            phantom: PhantomData,
         }
     }
 
@@ -828,18 +850,7 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
         I: Iterator<Item = T>,
     {
         Arc::from_header_and_iter_alloc(
-            |layout| {
-                // align will only ever be align_of::<usize>() or align_of::<u64>()
-                let align = layout.align();
-                unsafe {
-                    if align == mem::align_of::<usize>() {
-                        Self::allocate_buffer::<usize>(layout.size())
-                    } else {
-                        assert_eq!(align, mem::align_of::<u64>());
-                        Self::allocate_buffer::<u64>(layout.size())
-                    }
-                }
-            },
+            |layout| unsafe { alloc::alloc(layout) },
             header,
             items,
             num_items,
@@ -856,17 +867,6 @@ impl<H, T> Arc<HeaderSlice<H, T>> {
     {
         let len = items.len();
         Self::from_header_and_iter_with_size(header, items, len)
-    }
-
-    #[inline]
-    unsafe fn allocate_buffer<W>(size: usize) -> *mut u8 {
-        // We use Vec because the underlying allocation machinery isn't
-        // available in stable Rust. To avoid alignment issues, we allocate
-        // words rather than bytes, rounding up to the nearest word size.
-        let words_to_allocate = divide_rounding_up(size, mem::size_of::<W>());
-        let mut vec = Vec::<W>::with_capacity(words_to_allocate);
-        vec.set_len(words_to_allocate);
-        Box::into_raw(vec.into_boxed_slice()) as *mut W as *mut u8
     }
 }
 

--- a/servo_arc/lib.rs
+++ b/servo_arc/lib.rs
@@ -45,7 +45,6 @@ use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
 use std::process;
 use std::ptr;
-use std::slice;
 use std::sync::atomic;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use std::{isize, usize};
@@ -351,6 +350,11 @@ impl<T: ?Sized> Arc<T> {
     fn ptr(&self) -> *mut ArcInner<T> {
         self.p.as_ptr()
     }
+
+    /// Returns a raw ptr to the underlying allocation.
+    pub fn raw_ptr(&self) -> *const c_void {
+        self.p.as_ptr() as *const _
+    }
 }
 
 #[cfg(feature = "gecko_refcount_logging")]
@@ -643,14 +647,68 @@ impl<T: Serialize> Serialize for Arc<T> {
 
 /// Structure to allow Arc-managing some fixed-sized data and a variably-sized
 /// slice in a single allocation.
-#[derive(Debug, Eq, PartialEq, PartialOrd)]
+///
+/// cbindgen:derive-eq=false
+/// cbindgen:derive-neq=false
+#[derive(Debug, Eq)]
 #[repr(C)]
-pub struct HeaderSlice<H, T: ?Sized> {
+pub struct HeaderSlice<H, T> {
     /// The fixed-sized data.
     pub header: H,
 
+    /// The length of the slice at our end.
+    len: usize,
+
     /// The dynamically-sized data.
-    pub slice: T,
+    data: [T; 0],
+}
+
+impl<H: PartialEq, T: PartialEq> PartialEq for HeaderSlice<H, T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.header == other.header && self.slice() == other.slice()
+    }
+}
+
+impl<H, T> Drop for HeaderSlice<H, T> {
+    fn drop(&mut self) {
+        unsafe {
+            let mut ptr = self.data.as_mut_ptr();
+            for _ in 0..self.len {
+                std::ptr::drop_in_place(ptr);
+                ptr = ptr.offset(1);
+            }
+        }
+    }
+}
+
+impl<H, T> HeaderSlice<H, T> {
+    /// Returns the dynamically sized slice in this HeaderSlice.
+    #[inline(always)]
+    pub fn slice(&self) -> &[T] {
+        unsafe { std::slice::from_raw_parts(self.data(), self.len) }
+    }
+
+    #[inline(always)]
+    fn data(&self) -> *const T {
+        std::ptr::addr_of!(self.data) as *const _
+    }
+
+    #[inline(always)]
+    fn data_mut(&mut self) -> *mut T {
+        std::ptr::addr_of_mut!(self.data) as *mut _
+    }
+
+    /// Returns the dynamically sized slice in this HeaderSlice.
+    #[inline(always)]
+    pub fn slice_mut(&mut self) -> &mut [T] {
+        unsafe { std::slice::from_raw_parts_mut(self.data_mut(), self.len) }
+    }
+
+    /// Returns the len of the slice.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
 }
 
 #[inline(always)]
@@ -658,7 +716,7 @@ fn divide_rounding_up(dividend: usize, divisor: usize) -> usize {
     (dividend + divisor - 1) / divisor
 }
 
-impl<H, T> Arc<HeaderSlice<H, [T]>> {
+impl<H, T> Arc<HeaderSlice<H, T>> {
     /// Creates an Arc for a HeaderSlice using the given header struct and
     /// iterator to generate the slice.
     ///
@@ -671,7 +729,7 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
     /// then `alloc` must return an allocation that can be dellocated
     /// by calling Box::from_raw::<ArcInner<HeaderSlice<H, T>>> on it.
     #[inline]
-    fn from_header_and_iter_alloc<F, I>(
+    pub fn from_header_and_iter_alloc<F, I>(
         alloc: F,
         header: H,
         mut items: I,
@@ -684,31 +742,11 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
     {
         assert_ne!(size_of::<T>(), 0, "Need to think about ZST");
 
-        let inner_align = align_of::<ArcInner<HeaderSlice<H, [T; 0]>>>();
+        let size = size_of::<ArcInner<HeaderSlice<H, T>>>() + size_of::<T>() * num_items;
+        let inner_align = align_of::<ArcInner<HeaderSlice<H, T>>>();
         debug_assert!(inner_align >= align_of::<T>());
 
-        // Compute the required size for the allocation.
-        let size = {
-            // Next, synthesize a totally garbage (but properly aligned) pointer
-            // to a sequence of T.
-            let fake_slice_ptr = inner_align as *const T;
-
-            // Convert that sequence to a fat pointer. The address component of
-            // the fat pointer will be garbage, but the length will be correct.
-            let fake_slice = unsafe { slice::from_raw_parts(fake_slice_ptr, num_items) };
-
-            // Pretend the garbage address points to our allocation target (with
-            // a trailing sequence of T), rather than just a sequence of T.
-            let fake_ptr = fake_slice as *const [T] as *const ArcInner<HeaderSlice<H, [T]>>;
-            let fake_ref: &ArcInner<HeaderSlice<H, [T]>> = unsafe { &*fake_ptr };
-
-            // Use size_of_val, which will combine static information about the
-            // type with the length from the fat pointer. The garbage address
-            // will not be used.
-            mem::size_of_val(fake_ref)
-        };
-
-        let ptr: *mut ArcInner<HeaderSlice<H, [T]>>;
+        let ptr: *mut ArcInner<HeaderSlice<H, T>>;
         unsafe {
             // Allocate the buffer.
             let layout = if inner_align <= align_of::<usize>() {
@@ -723,15 +761,7 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             };
 
             let buffer = alloc(layout);
-
-            // Synthesize the fat pointer. We do this by claiming we have a direct
-            // pointer to a [T], and then changing the type of the borrow. The key
-            // point here is that the length portion of the fat pointer applies
-            // only to the number of elements in the dynamically-sized portion of
-            // the type, so the value will be the same whether it points to a [T]
-            // or something else with a [T] as its last member.
-            let fake_slice: &mut [T] = slice::from_raw_parts_mut(buffer as *mut T, num_items);
-            ptr = fake_slice as *mut [T] as *mut ArcInner<HeaderSlice<H, [T]>>;
+            ptr = buffer as *mut ArcInner<HeaderSlice<H, T>>;
 
             // Write the data.
             //
@@ -744,8 +774,9 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
             };
             ptr::write(&mut ((*ptr).count), count);
             ptr::write(&mut ((*ptr).data.header), header);
+            ptr::write(&mut ((*ptr).data.len), num_items);
             if num_items != 0 {
-                let mut current: *mut T = &mut (*ptr).data.slice[0];
+                let mut current = std::ptr::addr_of_mut!((*ptr).data.data) as *mut T;
                 for _ in 0..num_items {
                     ptr::write(
                         current,
@@ -778,8 +809,8 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
         // Return the fat Arc.
         assert_eq!(
             size_of::<Self>(),
-            size_of::<usize>() * 2,
-            "The Arc will be fat"
+            size_of::<usize>(),
+            "The Arc should be thin"
         );
         unsafe {
             Arc {
@@ -839,70 +870,16 @@ impl<H, T> Arc<HeaderSlice<H, [T]>> {
     }
 }
 
-/// Header data with an inline length. Consumers that use HeaderWithLength as the
-/// Header type in HeaderSlice can take advantage of ThinArc.
-#[derive(Debug, Eq, PartialEq, PartialOrd)]
-#[repr(C)]
-pub struct HeaderWithLength<H> {
-    /// The fixed-sized data.
-    pub header: H,
-
-    /// The slice length.
-    length: usize,
-}
-
-impl<H> HeaderWithLength<H> {
-    /// Creates a new HeaderWithLength.
-    pub fn new(header: H, length: usize) -> Self {
-        HeaderWithLength { header, length }
-    }
-}
-
-type HeaderSliceWithLength<H, T> = HeaderSlice<HeaderWithLength<H>, T>;
-
-/// A "thin" `Arc` containing dynamically sized data
-///
 /// This is functionally equivalent to Arc<(H, [T])>
 ///
-/// When you create an `Arc` containing a dynamically sized type
-/// like `HeaderSlice<H, [T]>`, the `Arc` is represented on the stack
-/// as a "fat pointer", where the length of the slice is stored
-/// alongside the `Arc`'s pointer. In some situations you may wish to
-/// have a thin pointer instead, perhaps for FFI compatibility
-/// or space efficiency.
-///
-/// Note that we use `[T; 0]` in order to have the right alignment for `T`.
-///
-/// `ThinArc` solves this by storing the length in the allocation itself,
-/// via `HeaderSliceWithLength`.
-#[repr(C)]
-pub struct ThinArc<H, T> {
-    ptr: ptr::NonNull<ArcInner<HeaderSliceWithLength<H, [T; 0]>>>,
-    phantom: PhantomData<(H, T)>,
-}
+/// When you create an `Arc` containing a dynamically sized type like a slice, the `Arc` is
+/// represented on the stack as a "fat pointer", where the length of the slice is stored alongside
+/// the `Arc`'s pointer. In some situations you may wish to have a thin pointer instead, perhaps
+/// for FFI compatibility or space efficiency. `ThinArc` solves this by storing the length in the
+/// allocation itself, via `HeaderSlice`.
+pub type ThinArc<H, T> = Arc<HeaderSlice<H, T>>;
 
-impl<H: fmt::Debug, T: fmt::Debug> fmt::Debug for ThinArc<H, T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(self.deref(), f)
-    }
-}
-
-unsafe impl<H: Sync + Send, T: Sync + Send> Send for ThinArc<H, T> {}
-unsafe impl<H: Sync + Send, T: Sync + Send> Sync for ThinArc<H, T> {}
-
-// Synthesize a fat pointer from a thin pointer.
-//
-// See the comment around the analogous operation in from_header_and_iter.
-fn thin_to_thick<H, T>(
-    thin: *mut ArcInner<HeaderSliceWithLength<H, [T; 0]>>,
-) -> *mut ArcInner<HeaderSliceWithLength<H, [T]>> {
-    let len = unsafe { (*thin).data.header.length };
-    let fake_slice: *mut [T] = unsafe { slice::from_raw_parts_mut(thin as *mut T, len) };
-
-    fake_slice as *mut ArcInner<HeaderSliceWithLength<H, [T]>>
-}
-
-impl<H, T> ThinArc<H, T> {
+impl<H, T> UniqueArc<HeaderSlice<H, T>> {
     /// Returns the dynamically sized slice in this HeaderSlice.
     #[inline(always)]
     pub fn slice(&self) -> &[T] {
@@ -915,144 +892,8 @@ impl<H, T> ThinArc<H, T> {
         self.slice.len()
     }
 
-    /// Temporarily converts |self| into a bonafide Arc and exposes it to the
-    /// provided callback. The refcount is not modified.
     #[inline]
-    pub fn with_arc<F, U>(&self, f: F) -> U
-    where
-        F: FnOnce(&Arc<HeaderSliceWithLength<H, [T]>>) -> U,
-    {
-        // Synthesize transient Arc, which never touches the refcount of the ArcInner.
-        let transient = unsafe {
-            mem::ManuallyDrop::new(Arc {
-                p: ptr::NonNull::new_unchecked(thin_to_thick(self.ptr.as_ptr())),
-                phantom: PhantomData,
-            })
-        };
-
-        // Expose the transient Arc to the callback, which may clone it if it wants.
-        let result = f(&transient);
-
-        // Forward the result.
-        result
-    }
-
-    /// Creates a `ThinArc` for a HeaderSlice using the given header struct and
-    /// iterator to generate the slice.
     pub fn from_header_and_iter<I>(header: H, items: I) -> Self
-    where
-        I: Iterator<Item = T> + ExactSizeIterator,
-    {
-        let header = HeaderWithLength::new(header, items.len());
-        Arc::into_thin(Arc::from_header_and_iter(header, items))
-    }
-
-    /// Create a static `ThinArc` for a HeaderSlice using the given header
-    /// struct and iterator to generate the slice, placing it in the allocation
-    /// provided by the specified `alloc` function.
-    ///
-    /// `alloc` must return a pointer into a static allocation suitable for
-    /// storing data with the `Layout` passed into it. The pointer returned by
-    /// `alloc` will not be freed.
-    pub unsafe fn static_from_header_and_iter<F, I>(alloc: F, header: H, items: I) -> Self
-    where
-        F: FnOnce(Layout) -> *mut u8,
-        I: Iterator<Item = T> + ExactSizeIterator,
-    {
-        let len = items.len();
-        let header = HeaderWithLength::new(header, len);
-        Arc::into_thin(Arc::from_header_and_iter_alloc(
-            alloc, header, items, len, /* is_static = */ true,
-        ))
-    }
-
-    /// Returns the address on the heap of the ThinArc itself -- not the T
-    /// within it -- for memory reporting, and bindings.
-    #[inline]
-    pub fn ptr(&self) -> *const c_void {
-        self.ptr.as_ptr() as *const ArcInner<T> as *const c_void
-    }
-
-    /// If this is a static ThinArc, this returns null.
-    #[inline]
-    pub fn heap_ptr(&self) -> *const c_void {
-        let is_static =
-            ThinArc::with_arc(self, |a| a.inner().count.load(Relaxed) == STATIC_REFCOUNT);
-        if is_static {
-            ptr::null()
-        } else {
-            self.ptr()
-        }
-    }
-}
-
-impl<H, T> Deref for ThinArc<H, T> {
-    type Target = HeaderSliceWithLength<H, [T]>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        unsafe { &(*thin_to_thick(self.ptr.as_ptr())).data }
-    }
-}
-
-impl<H, T> Clone for ThinArc<H, T> {
-    #[inline]
-    fn clone(&self) -> Self {
-        ThinArc::with_arc(self, |a| Arc::into_thin(a.clone()))
-    }
-}
-
-impl<H, T> Drop for ThinArc<H, T> {
-    #[inline]
-    fn drop(&mut self) {
-        let _ = Arc::from_thin(ThinArc {
-            ptr: self.ptr,
-            phantom: PhantomData,
-        });
-    }
-}
-
-impl<H, T> Arc<HeaderSliceWithLength<H, [T]>> {
-    /// Converts an `Arc` into a `ThinArc`. This consumes the `Arc`, so the refcount
-    /// is not modified.
-    #[inline]
-    pub fn into_thin(a: Self) -> ThinArc<H, T> {
-        assert_eq!(
-            a.header.length,
-            a.slice.len(),
-            "Length needs to be correct for ThinArc to work"
-        );
-        let fat_ptr: *mut ArcInner<HeaderSliceWithLength<H, [T]>> = a.ptr();
-        mem::forget(a);
-        let thin_ptr = fat_ptr as *mut [usize] as *mut usize;
-        ThinArc {
-            ptr: unsafe {
-                ptr::NonNull::new_unchecked(
-                    thin_ptr as *mut ArcInner<HeaderSliceWithLength<H, [T; 0]>>,
-                )
-            },
-            phantom: PhantomData,
-        }
-    }
-
-    /// Converts a `ThinArc` into an `Arc`. This consumes the `ThinArc`, so the refcount
-    /// is not modified.
-    #[inline]
-    pub fn from_thin(a: ThinArc<H, T>) -> Self {
-        let ptr = thin_to_thick(a.ptr.as_ptr());
-        mem::forget(a);
-        unsafe {
-            Arc {
-                p: ptr::NonNull::new_unchecked(ptr),
-                phantom: PhantomData,
-            }
-        }
-    }
-}
-
-impl<H, T> UniqueArc<HeaderSliceWithLength<H, [T]>> {
-    #[inline]
-    pub fn from_header_and_iter<I>(header: HeaderWithLength<H>, items: I) -> Self
     where
         I: Iterator<Item = T> + ExactSizeIterator,
     {
@@ -1061,7 +902,7 @@ impl<H, T> UniqueArc<HeaderSliceWithLength<H, [T]>> {
 
     #[inline]
     pub fn from_header_and_iter_with_size<I>(
-        header: HeaderWithLength<H>,
+        header: H,
         items: I,
         num_items: usize,
     ) -> Self
@@ -1076,28 +917,15 @@ impl<H, T> UniqueArc<HeaderSliceWithLength<H, [T]>> {
     /// Returns a mutable reference to the header.
     pub fn header_mut(&mut self) -> &mut H {
         // We know this to be uniquely owned
-        unsafe { &mut (*self.0.ptr()).data.header.header }
+        unsafe { &mut (*self.0.ptr()).data.header }
     }
 
     /// Returns a mutable reference to the slice.
     pub fn data_mut(&mut self) -> &mut [T] {
         // We know this to be uniquely owned
-        unsafe { &mut (*self.0.ptr()).data.slice }
-    }
-
-    pub fn shareable_thin(self) -> ThinArc<H, T> {
-        Arc::into_thin(self.0)
+        unsafe { (*self.0.ptr()).data.slice_mut() }
     }
 }
-
-impl<H: PartialEq, T: PartialEq> PartialEq for ThinArc<H, T> {
-    #[inline]
-    fn eq(&self, other: &ThinArc<H, T>) -> bool {
-        ThinArc::with_arc(self, |a| ThinArc::with_arc(other, |b| *a == *b))
-    }
-}
-
-impl<H: Eq, T: Eq> Eq for ThinArc<H, T> {}
 
 /// A "borrowed `Arc`". This is a pointer to
 /// a T that is known to have been allocated within an
@@ -1319,7 +1147,7 @@ impl<A: fmt::Debug, B: fmt::Debug> fmt::Debug for ArcUnion<A, B> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Arc, HeaderWithLength, ThinArc};
+    use super::{Arc, ThinArc};
     use std::clone::Clone;
     use std::ops::Drop;
     use std::sync::atomic;
@@ -1338,13 +1166,9 @@ mod tests {
 
     #[test]
     fn empty_thin() {
-        let header = HeaderWithLength::new(100u32, 0);
-        let x = Arc::from_header_and_iter(header, std::iter::empty::<i32>());
-        let y = Arc::into_thin(x.clone());
-        assert_eq!(y.header.header, 100);
-        assert!(y.slice.is_empty());
-        assert_eq!(x.header.header, 100);
-        assert!(x.slice.is_empty());
+        let x = Arc::from_header_and_iter(100u32, std::iter::empty::<i32>());
+        assert_eq!(x.header, 100);
+        assert!(x.slice().is_empty());
     }
 
     #[test]
@@ -1356,12 +1180,11 @@ mod tests {
         }
 
         // The header will have more alignment than `Padded`
-        let header = HeaderWithLength::new(0i32, 2);
         let items = vec![Padded { i: 0xdead }, Padded { i: 0xbeef }];
-        let a = ThinArc::from_header_and_iter(header, items.into_iter());
-        assert_eq!(a.slice.len(), 2);
-        assert_eq!(a.slice[0].i, 0xdead);
-        assert_eq!(a.slice[1].i, 0xbeef);
+        let a = ThinArc::from_header_and_iter(0i32, items.into_iter());
+        assert_eq!(a.len(), 2);
+        assert_eq!(a.slice()[0].i, 0xdead);
+        assert_eq!(a.slice()[1].i, 0xbeef);
     }
 
     #[test]
@@ -1369,13 +1192,10 @@ mod tests {
         let mut canary = atomic::AtomicUsize::new(0);
         let c = Canary(&mut canary as *mut atomic::AtomicUsize);
         let v = vec![5, 6];
-        let header = HeaderWithLength::new(c, v.len());
         {
-            let x = Arc::into_thin(Arc::from_header_and_iter(header, v.into_iter()));
-            let y = ThinArc::with_arc(&x, |q| q.clone());
-            let _ = y.clone();
+            let x = Arc::from_header_and_iter(c, v.into_iter());
+            let _ = x.clone();
             let _ = x == x;
-            Arc::from_thin(x.clone());
         }
         assert_eq!(canary.load(Acquire), 1);
     }

--- a/style/properties_and_values/value.rs
+++ b/style/properties_and_values/value.rs
@@ -249,7 +249,7 @@ impl ToComputedValue for SpecifiedValueComponentList {
             .slice()
             .iter()
             .map(|item| item.to_computed_value(context));
-        ComputedValueComponentList::new(self.0.header.header, iter)
+        ComputedValueComponentList::new(self.0.header, iter)
     }
 
     fn from_computed_value(computed: &Self::ComputedValue) -> Self {
@@ -258,7 +258,7 @@ impl ToComputedValue for SpecifiedValueComponentList {
             .slice()
             .iter()
             .map(SpecifiedValueComponent::from_computed_value);
-        Self::new(computed.0.header.header, iter)
+        Self::new(computed.0.header, iter)
     }
 }
 
@@ -274,7 +274,7 @@ impl ToCss for SpecifiedValueComponentList {
         first.to_css(dest)?;
 
         // The separator implied by the multiplier for this list.
-        let separator = match self.0.header.header {
+        let separator = match self.0.header {
             // <https://drafts.csswg.org/cssom-1/#serialize-a-whitespace-separated-list>
             Multiplier::Space => " ",
             // <https://drafts.csswg.org/cssom-1/#serialize-a-comma-separated-list>

--- a/style/values/computed/font.rs
+++ b/style/values/computed/font.rs
@@ -397,7 +397,7 @@ impl FontFamily {
         generic_font_family!(MOZ_EMOJI, MozEmoji);
         generic_font_family!(SYSTEM_UI, SystemUi);
 
-        match generic {
+        let family = match generic {
             GenericFontFamily::None => {
                 debug_assert!(false, "Bogus caller!");
                 &*SERIF
@@ -410,7 +410,9 @@ impl FontFamily {
             #[cfg(feature = "gecko")]
             GenericFontFamily::MozEmoji => &*MOZ_EMOJI,
             GenericFontFamily::SystemUi => &*SYSTEM_UI,
-        }
+        };
+        debug_assert_eq!(*family.families.iter().next().unwrap(), SingleFontFamily::Generic(generic));
+        family
     }
 }
 

--- a/style/values/computed/font.rs
+++ b/style/values/computed/font.rs
@@ -411,7 +411,10 @@ impl FontFamily {
             GenericFontFamily::MozEmoji => &*MOZ_EMOJI,
             GenericFontFamily::SystemUi => &*SYSTEM_UI,
         };
-        debug_assert_eq!(*family.families.iter().next().unwrap(), SingleFontFamily::Generic(generic));
+        debug_assert_eq!(
+            *family.families.iter().next().unwrap(),
+            SingleFontFamily::Generic(generic)
+        );
         family
     }
 }

--- a/to_shmem/lib.rs
+++ b/to_shmem/lib.rs
@@ -20,7 +20,7 @@ extern crate smallvec;
 extern crate string_cache;
 extern crate thin_vec;
 
-use servo_arc::{Arc, ThinArc};
+use servo_arc::{Arc, HeaderSlice};
 use smallbitvec::{InternalStorage, SmallBitVec};
 use smallvec::{Array, SmallVec};
 use std::alloc::Layout;
@@ -463,7 +463,7 @@ impl<T: ToShmem> ToShmem for Arc<T> {
     }
 }
 
-impl<H: ToShmem, T: ToShmem> ToShmem for ThinArc<H, T> {
+impl<H: ToShmem, T: ToShmem> ToShmem for Arc<HeaderSlice<H, T>> {
     fn to_shmem(&self, builder: &mut SharedMemoryBuilder) -> Result<Self> {
         // We don't currently have any shared ThinArc values in stylesheets,
         // so don't support them for now.
@@ -476,26 +476,27 @@ impl<H: ToShmem, T: ToShmem> ToShmem for ThinArc<H, T> {
 
         // Make a clone of the Arc-owned header and slice values with all of
         // their heap allocations placed in the shared memory buffer.
-        let header = self.header.header.to_shmem(builder)?;
-        let mut values = Vec::with_capacity(self.slice.len());
-        for v in self.slice.iter() {
+        let header = self.header.to_shmem(builder)?;
+        let mut values = Vec::with_capacity(self.len());
+        for v in self.slice().iter() {
             values.push(v.to_shmem(builder)?);
         }
 
         // Create a new ThinArc with the shared value and have it place
         // its ArcInner in the shared memory buffer.
-        unsafe {
-            let static_arc = ThinArc::static_from_header_and_iter(
-                |layout| builder.alloc(layout),
-                ManuallyDrop::into_inner(header),
-                values.into_iter().map(ManuallyDrop::into_inner),
-            );
+        let len = values.len();
+        let static_arc = Self::from_header_and_iter_alloc(
+            |layout| builder.alloc(layout),
+            ManuallyDrop::into_inner(header),
+            values.into_iter().map(ManuallyDrop::into_inner),
+            len,
+            /* is_static = */ true,
+        );
 
-            #[cfg(debug_assertions)]
-            builder.shared_values.insert(self.heap_ptr());
+        #[cfg(debug_assertions)]
+        builder.shared_values.insert(self.heap_ptr());
 
-            Ok(ManuallyDrop::new(static_arc))
-        }
+        Ok(ManuallyDrop::new(static_arc))
     }
 }
 


### PR DESCRIPTION
I reverted 516aec4 because it was making Servo crash.
This relands it together with 63a6a2d3e, with avoids the crashes.