### PR TITLE
Add support of style & color for `text-decoration`

### DIFF
--- a/style/properties/shorthands/text.mako.rs
+++ b/style/properties/shorthands/text.mako.rs
@@ -7,23 +7,21 @@
 <%helpers:shorthand name="text-decoration"
                     engines="gecko servo"
                     flags="SHORTHAND_IN_GETCS"
-                    sub_properties="text-decoration-line
-                    ${' text-decoration-style text-decoration-color text-decoration-thickness' if engine == 'gecko' else ''}"
+                    sub_properties="text-decoration-color text-decoration-line text-decoration-style
+                    ${' text-decoration-thickness' if engine == 'gecko' else ''}"
                     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration">
+    use crate::properties::longhands::{text_decoration_color, text_decoration_line, text_decoration_style};
     % if engine == "gecko":
-        use crate::values::specified;
-        use crate::properties::longhands::{text_decoration_style, text_decoration_color, text_decoration_thickness};
+        use crate::properties::longhands::text_decoration_thickness;
     % endif
-    use crate::properties::longhands::text_decoration_line;
 
     pub fn parse_value<'i, 't>(
         context: &ParserContext,
         input: &mut Parser<'i, 't>,
     ) -> Result<Longhands, ParseError<'i>> {
+        let (mut line, mut style, mut color, mut any) = (None, None, None, false);
         % if engine == "gecko":
-            let (mut line, mut style, mut color, mut thickness, mut any) = (None, None, None, None, false);
-        % else:
-            let (mut line, mut any) = (None, false);
+            let mut thickness = None;
         % endif
 
         loop {
@@ -40,10 +38,10 @@
             }
 
             parse_component!(line, text_decoration_line);
+            parse_component!(style, text_decoration_style);
+            parse_component!(color, text_decoration_color);
 
             % if engine == "gecko":
-                parse_component!(style, text_decoration_style);
-                parse_component!(color, text_decoration_color);
                 parse_component!(thickness, text_decoration_thickness);
             % endif
 
@@ -56,10 +54,9 @@
 
         Ok(expanded! {
             text_decoration_line: unwrap_or_initial!(text_decoration_line, line),
-
+            text_decoration_style: unwrap_or_initial!(text_decoration_style, style),
+            text_decoration_color: unwrap_or_initial!(text_decoration_color, color),
             % if engine == "gecko":
-                text_decoration_style: unwrap_or_initial!(text_decoration_style, style),
-                text_decoration_color: unwrap_or_initial!(text_decoration_color, color),
                 text_decoration_thickness: unwrap_or_initial!(text_decoration_thickness, thickness),
             % endif
         })
@@ -69,17 +66,19 @@
         #[allow(unused)]
         fn to_css<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result where W: fmt::Write {
             use crate::values::specified::TextDecorationLine;
+            use crate::values::specified::Color;
 
-            let (is_solid_style, is_current_color, is_auto_thickness) =
+            let (is_solid_style, is_current_color) =
             (
-            % if engine == "gecko":
                 *self.text_decoration_style == text_decoration_style::SpecifiedValue::Solid,
-                *self.text_decoration_color == specified::Color::CurrentColor,
-                self.text_decoration_thickness.is_auto()
-            % else:
-                true, true, true
-            % endif
+                *self.text_decoration_color == Color::CurrentColor,
             );
+
+            % if engine == "gecko":
+                let is_auto_thickness = self.text_decoration_thickness.is_auto();
+            % else:
+                let is_auto_thickness = true;
+            % endif
 
             let mut has_value = false;
             let is_none = *self.text_decoration_line == TextDecorationLine::none();
@@ -96,6 +95,7 @@
                 self.text_decoration_thickness.to_css(dest)?;
                 has_value = true;
             }
+            % endif
 
             if !is_solid_style {
                 if has_value {
@@ -112,7 +112,6 @@
                 self.text_decoration_color.to_css(dest)?;
                 has_value = true;
             }
-            % endif
 
             Ok(())
         }


### PR DESCRIPTION
This pull request is a continuation of #31, which was closed due to the need for rebasing. I have rebased my changes as requested by the maintainer.

## Changes
- Updated the `sub_properties` attribute of the `text-decoration` shorthand to include `text-decoration-style` and `text-decoration-color` for the Servo engine.
- Modified the `parse_value` function to parse `text-decoration-style` and `text-decoration-color` properties when the engine is Servo. The parsed values are stored in the `style` and `color` variables, respectively.
- Updated the `ToCss` implementation to serialize `text-decoration-style` and `text-decoration-color` properties for the Servo engine.

These changes ensure that the `text-decoration` shorthand in Servo correctly parses and serializes the `text-decoration-style` and `text-decoration-color` properties, providing a complete implementation of the shorthand.

Resolves: #25