### PR TITLE
Turn white-space into a shorthand

### DIFF
--- a/style/properties/data.py
+++ b/style/properties/data.py
@@ -881,15 +881,13 @@ def _remove_common_first_line_and_first_letter_properties(props, engine):
         props.remove("text-emphasis-position")
         props.remove("text-emphasis-style")
         props.remove("text-emphasis-color")
-        props.remove("text-wrap-mode")
         props.remove("text-wrap-style")
-        props.remove("white-space-collapse")
-    else:
-        props.remove("white-space")
 
     props.remove("overflow-wrap")
     props.remove("text-align")
     props.remove("text-justify")
+    props.remove("white-space-collapse")
+    props.remove("text-wrap-mode")
     props.remove("word-break")
     props.remove("text-indent")
 

--- a/style/properties/longhands/inherited_text.mako.rs
+++ b/style/properties/longhands/inherited_text.mako.rs
@@ -145,58 +145,17 @@ ${helpers.predefined_type(
     affects="layout",
 )}
 
-<%helpers:single_keyword
-    name="white-space"
-    values="normal pre nowrap pre-wrap pre-line"
-    engines="servo",
-    gecko_enum_prefix="StyleWhiteSpace"
-    needs_conversion="True"
-    animation_value_type="discrete"
-    spec="https://drafts.csswg.org/css-text/#propdef-white-space"
-    servo_restyle_damage="rebuild_and_reflow"
-    affects="layout"
->
-    impl SpecifiedValue {
-        pub fn allow_wrap(&self) -> bool {
-            match *self {
-                SpecifiedValue::Nowrap |
-                SpecifiedValue::Pre => false,
-                SpecifiedValue::Normal |
-                SpecifiedValue::PreWrap |
-                SpecifiedValue::PreLine => true,
-            }
-        }
-
-        pub fn preserve_newlines(&self) -> bool {
-            match *self {
-                SpecifiedValue::Normal |
-                SpecifiedValue::Nowrap => false,
-                SpecifiedValue::Pre |
-                SpecifiedValue::PreWrap |
-                SpecifiedValue::PreLine => true,
-            }
-        }
-
-        pub fn preserve_spaces(&self) -> bool {
-            match *self {
-                SpecifiedValue::Normal |
-                SpecifiedValue::Nowrap |
-                SpecifiedValue::PreLine => false,
-                SpecifiedValue::Pre |
-                SpecifiedValue::PreWrap => true,
-            }
-        }
-    }
-</%helpers:single_keyword>
-
 // TODO: `white-space-collapse: discard` not yet supported
 ${helpers.single_keyword(
     name="white-space-collapse",
-    values="collapse preserve preserve-breaks preserve-spaces break-spaces",
-    engines="gecko",
+    values="collapse preserve preserve-breaks",
+    extra_gecko_values="preserve-spaces break-spaces",
+    engines="gecko servo",
     gecko_enum_prefix="StyleWhiteSpaceCollapse",
+    needs_conversion="True",
     animation_value_type="discrete",
     spec="https://drafts.csswg.org/css-text-4/#propdef-white-space-collapse",
+    servo_restyle_damage="rebuild_and_reflow",
     affects="layout",
 )}
 
@@ -434,10 +393,12 @@ ${helpers.single_keyword(
 ${helpers.single_keyword(
     "text-wrap-mode",
     "wrap nowrap",
-    engines="gecko",
+    engines="gecko servo",
     gecko_enum_prefix="StyleTextWrapMode",
+    needs_conversion="True",
     animation_value_type="discrete",
     spec="https://drafts.csswg.org/css-text-4/#propdef-text-wrap-mode",
+    servo_restyle_damage="rebuild_and_reflow",
     affects="layout",
 )}
 

--- a/style/properties/shorthands/inherited_text.mako.rs
+++ b/style/properties/shorthands/inherited_text.mako.rs
@@ -107,7 +107,7 @@
 
 <%helpers:shorthand
     name="white-space"
-    engines="gecko"
+    engines="gecko servo"
     sub_properties="text-wrap-mode white-space-collapse"
     spec="https://www.w3.org/TR/css-text-4/#white-space-property"
 >
@@ -128,6 +128,7 @@
                 "pre-line" => (Wrap::Wrap, Collapse::PreserveBreaks),
                 // TODO: deprecate/remove -moz-pre-space; the white-space-collapse: preserve-spaces value
                 // should serve this purpose?
+                #[cfg(feature = "gecko")]
                 "-moz-pre-space" => (Wrap::Wrap, Collapse::PreserveSpaces),
             };
             Ok(expanded! {
@@ -180,7 +181,9 @@
                         Collapse::Collapse => return dest.write_str("normal"),
                         Collapse::Preserve => return dest.write_str("pre-wrap"),
                         Collapse::PreserveBreaks => return dest.write_str("pre-line"),
+                        #[cfg(feature = "gecko")]
                         Collapse::PreserveSpaces => return dest.write_str("-moz-pre-space"),
+                        #[cfg(feature = "gecko")]
                         _ => (),
                     }
                 },


### PR DESCRIPTION
Split it into `white-space-collapse` and `text-wrap-mode`:

| white-space | white-space-collapse | text-wrap-mode |
| ----------- | -------------------- | -------------- |
| normal      | collapse             | wrap           |
| nowrap      | collapse             | nowrap         |
| pre-wrap    | preserve             | wrap           |
| pre         | preserve             | nowrap         |
| pre-line    | preserve-breaks      | wrap           |
| -           | preserve-breaks      | nowrap         |

Note this introduces a combination that wasn't previously possible.