### PR TITLE
Update keyboard-types to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,11 +629,11 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "keyboard-types"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7668b7cff6a51fe61cdde64cd27c8a220786f399501b57ebe36f7d8112fd68"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "serde",
  "unicode-segmentation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ ipc-channel = "0.18"
 itertools = "0.12"
 jemallocator = "0.5.4"
 jemalloc-sys = "0.5.4"
-keyboard-types = "0.6"
+keyboard-types = "0.7"
 layout_traits = { path = "components/shared/layout" }
 lazy_static = "1.4"
 libc = "0.2"


### PR DESCRIPTION
keyboard-types 0.7 is good because (among other things) it now includes NamedKey::F25..=F35
Part of https://github.com/servo/servo/pull/32228