### PR TITLE
Enable `border-collapse` for non-legacy layout in Servo

### DIFF
--- a/style/properties/longhands/inherited_table.mako.rs
+++ b/style/properties/longhands/inherited_table.mako.rs
@@ -8,7 +8,6 @@ ${helpers.single_keyword(
     "border-collapse",
     "separate collapse",
     engines="gecko servo",
-    servo_pref="layout.legacy_layout",
     gecko_enum_prefix="StyleBorderCollapse",
     animation_value_type="discrete",
     spec="https://drafts.csswg.org/css-tables/#propdef-border-collapse",


### PR DESCRIPTION

Co-authored-by: Oriol Brufau <obrufau@igalia.com>