### PR TITLE
Remove `SingleFontFamily::from_atom`

### DIFF
--- a/style/values/computed/font.rs
+++ b/style/values/computed/font.rs
@@ -680,39 +680,6 @@ impl Parse for SingleFontFamily {
     }
 }
 
-#[cfg(feature = "servo")]
-impl SingleFontFamily {
-    /// Get the corresponding font-family with Atom
-    pub fn from_atom(input: Atom) -> SingleFontFamily {
-        match input {
-            atom!("serif") => return SingleFontFamily::Generic(GenericFontFamily::Serif),
-            atom!("sans-serif") => return SingleFontFamily::Generic(GenericFontFamily::SansSerif),
-            atom!("cursive") => return SingleFontFamily::Generic(GenericFontFamily::Cursive),
-            atom!("fantasy") => return SingleFontFamily::Generic(GenericFontFamily::Fantasy),
-            atom!("monospace") => return SingleFontFamily::Generic(GenericFontFamily::Monospace),
-            atom!("system-ui") => return SingleFontFamily::Generic(GenericFontFamily::SystemUi),
-            _ => {},
-        }
-
-        match_ignore_ascii_case! { &input,
-            "serif" => return SingleFontFamily::Generic(GenericFontFamily::Serif),
-            "sans-serif" => return SingleFontFamily::Generic(GenericFontFamily::SansSerif),
-            "cursive" => return SingleFontFamily::Generic(GenericFontFamily::Cursive),
-            "fantasy" => return SingleFontFamily::Generic(GenericFontFamily::Fantasy),
-            "monospace" => return SingleFontFamily::Generic(GenericFontFamily::Monospace),
-            "system-ui" => return SingleFontFamily::Generic(GenericFontFamily::SystemUi),
-            _ => {}
-        }
-
-        // We don't know if it's quoted or not. So we set it to
-        // quoted by default.
-        SingleFontFamily::FamilyName(FamilyName {
-            name: input,
-            syntax: FontFamilyNameSyntax::Quoted,
-        })
-    }
-}
-
 /// A list of font families.
 #[cfg(feature = "gecko")]
 #[derive(Clone, Debug, ToComputedValue, ToResolvedValue, ToShmem, PartialEq, Eq)]


### PR DESCRIPTION
This Servo-only function is no longer used after servo/servo#32622.
