### PR TITLE
Remove impl_align_conversions

### DIFF
--- a/style/properties/longhands/position.mako.rs
+++ b/style/properties/longhands/position.mako.rs
@@ -35,24 +35,6 @@
     )}
 % endfor
 
-#[cfg(feature = "gecko")]
-macro_rules! impl_align_conversions {
-    ($name: path) => {
-        impl From<u8> for $name {
-            fn from(bits: u8) -> $name {
-                $name(crate::values::specified::align::AlignFlags::from_bits(bits)
-                      .expect("bits contain valid flag"))
-            }
-        }
-
-        impl From<$name> for u8 {
-            fn from(v: $name) -> u8 {
-                v.0.bits()
-            }
-        }
-    };
-}
-
 ${helpers.predefined_type(
     "z-index",
     "ZIndex",
@@ -196,9 +178,6 @@ ${helpers.single_keyword(
         affects="layout",
     )}
 
-    #[cfg(feature = "gecko")]
-    impl_align_conversions!(crate::values::specified::align::AlignItems);
-
     ${helpers.predefined_type(
         "justify-items",
         "JustifyItems",
@@ -208,9 +187,6 @@ ${helpers.single_keyword(
         animation_value_type="discrete",
         affects="layout",
     )}
-
-    #[cfg(feature = "gecko")]
-    impl_align_conversions!(crate::values::specified::align::JustifyItems);
 % endif
 
 // Flex item properties
@@ -276,9 +252,6 @@ ${helpers.predefined_type(
         animation_value_type="discrete",
         affects="layout",
     )}
-
-    #[cfg(feature = "gecko")]
-    impl_align_conversions!(crate::values::specified::align::SelfAlignment);
 % endif
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order


### PR DESCRIPTION
These lines:

- Were introduced in the "Commit all other changes from Servo" commit (I wont put a git commit id due to the frequent rebasing in this repo)
- Are `#[cfg(feature = "gecko")]`
- Are not present in upstream Stylo

I therefore conclude that we can safely remove them from our downstream copy.

I believe commit could even be squashed into the "Commit all other changes from Servo" commit next time `main` is being rebased (which would simplify the history as the change would disappear entirely rather than being introduced and then removed again).