### PR TITLE
Switch to Gecko's representation of alignment styles

### DIFF
--- a/style/properties/longhands/position.mako.rs
+++ b/style/properties/longhands/position.mako.rs
@@ -75,119 +75,52 @@ ${helpers.single_keyword(
     affects="layout",
 )}
 
-% if engine in "servo":
-    // FIXME: Update Servo to support the same Syntax as Gecko.
-    ${helpers.single_keyword(
-        "justify-content",
-        "start flex-start stretch end flex-end center space-between space-around space-evenly",
-        engines="servo",
-        servo_pref="layout.flexbox.enabled",
-        extra_prefixes="webkit",
-        spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
-        animation_value_type="discrete",
-        servo_restyle_damage = "reflow",
-        affects="layout",
-    )}
-% endif
-% if engine == "gecko":
-    ${helpers.predefined_type(
-        "justify-content",
-        "JustifyContent",
-        "specified::JustifyContent(specified::ContentDistribution::normal())",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
-        extra_prefixes="webkit",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        affects="layout",
-    )}
+${helpers.predefined_type(
+    "justify-content",
+    "JustifyContent",
+    "specified::JustifyContent(specified::ContentDistribution::normal())",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
+    extra_prefixes="webkit",
+    animation_value_type="discrete",
+    servo_restyle_damage="reflow",
+    affects="layout",
+)}
 
-    ${helpers.predefined_type(
-        "justify-tracks",
-        "JustifyTracks",
-        "specified::JustifyTracks::default()",
-        engines="gecko",
-        gecko_pref="layout.css.grid-template-masonry-value.enabled",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        spec="https://github.com/w3c/csswg-drafts/issues/4650",
-        affects="layout",
-    )}
-% endif
+${helpers.predefined_type(
+    "align-content",
+    "AlignContent",
+    "specified::AlignContent(specified::ContentDistribution::normal())",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#propdef-align-content",
+    extra_prefixes="webkit",
+    animation_value_type="discrete",
+    servo_restyle_damage="reflow",
+    affects="layout",
+)}
 
-% if engine == "servo":
-    // FIXME: Update Servo to support the same Syntax as Gecko.
-    ${helpers.single_keyword(
-        "align-content",
-        "stretch start flex-start end flex-end center space-between space-around space-evenly",
-        engines="servo",
-        servo_pref="layout.flexbox.enabled",
-        extra_prefixes="webkit",
-        spec="https://drafts.csswg.org/css-align/#propdef-align-content",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        affects="layout",
-    )}
+${helpers.predefined_type(
+    "align-items",
+    "AlignItems",
+    "specified::AlignItems::normal()",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#propdef-align-items",
+    extra_prefixes="webkit",
+    animation_value_type="discrete",
+    servo_restyle_damage="reflow",
+    affects="layout",
+)}
 
-    ${helpers.single_keyword(
-        "align-items",
-        "stretch flex-start flex-end center baseline",
-        engines="servo",
-        servo_pref="layout.flexbox.enabled",
-        extra_prefixes="webkit",
-        spec="https://drafts.csswg.org/css-flexbox/#align-items-property",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        affects="layout",
-    )}
-% endif
-% if engine == "gecko":
-    ${helpers.predefined_type(
-        "align-content",
-        "AlignContent",
-        "specified::AlignContent(specified::ContentDistribution::normal())",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#propdef-align-content",
-        extra_prefixes="webkit",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        affects="layout",
-    )}
+${helpers.predefined_type(
+    "justify-items",
+    "JustifyItems",
+    "computed::JustifyItems::legacy()",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#propdef-justify-items",
+    animation_value_type="discrete",
+    affects="layout",
+)}
 
-    ${helpers.predefined_type(
-        "align-tracks",
-        "AlignTracks",
-        "specified::AlignTracks::default()",
-        engines="gecko",
-        gecko_pref="layout.css.grid-template-masonry-value.enabled",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        spec="https://github.com/w3c/csswg-drafts/issues/4650",
-        affects="layout",
-    )}
-
-    ${helpers.predefined_type(
-        "align-items",
-        "AlignItems",
-        "specified::AlignItems::normal()",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#propdef-align-items",
-        extra_prefixes="webkit",
-        animation_value_type="discrete",
-        servo_restyle_damage="reflow",
-        affects="layout",
-    )}
-
-    ${helpers.predefined_type(
-        "justify-items",
-        "JustifyItems",
-        "computed::JustifyItems::legacy()",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#propdef-justify-items",
-        animation_value_type="discrete",
-        affects="layout",
-    )}
-% endif
 
 // Flex item properties
 ${helpers.predefined_type(
@@ -195,7 +128,6 @@ ${helpers.predefined_type(
     "NonNegativeNumber",
     "From::from(0.0)",
     engines="gecko servo",
-    servo_pref="layout.flexbox.enabled",
     spec="https://drafts.csswg.org/css-flexbox/#flex-grow-property",
     extra_prefixes="webkit",
     animation_value_type="NonNegativeNumber",
@@ -217,42 +149,26 @@ ${helpers.predefined_type(
 )}
 
 // https://drafts.csswg.org/css-align/#align-self-property
-% if engine == "servo":
-    // FIXME: Update Servo to support the same syntax as Gecko.
-    ${helpers.single_keyword(
-        "align-self",
-        "auto stretch flex-start flex-end center baseline",
-        engines="servo",
-        servo_pref="layout.flexbox.enabled",
-        extra_prefixes="webkit",
-        spec="https://drafts.csswg.org/css-flexbox/#propdef-align-self",
-        animation_value_type="discrete",
-        servo_restyle_damage = "reflow",
-        affects="layout",
-    )}
-% endif
-% if engine == "gecko":
-    ${helpers.predefined_type(
-        "align-self",
-        "AlignSelf",
-        "specified::AlignSelf(specified::SelfAlignment::auto())",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#align-self-property",
-        extra_prefixes="webkit",
-        animation_value_type="discrete",
-        affects="layout",
-    )}
+${helpers.predefined_type(
+    "align-self",
+    "AlignSelf",
+    "specified::AlignSelf(specified::SelfAlignment::auto())",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#align-self-property",
+    extra_prefixes="webkit",
+    animation_value_type="discrete",
+    affects="layout",
+)}
 
-    ${helpers.predefined_type(
-        "justify-self",
-        "JustifySelf",
-        "specified::JustifySelf(specified::SelfAlignment::auto())",
-        engines="gecko",
-        spec="https://drafts.csswg.org/css-align/#justify-self-property",
-        animation_value_type="discrete",
-        affects="layout",
-    )}
-% endif
+${helpers.predefined_type(
+    "justify-self",
+    "JustifySelf",
+    "specified::JustifySelf(specified::SelfAlignment::auto())",
+    engines="gecko servo",
+    spec="https://drafts.csswg.org/css-align/#justify-self-property",
+    animation_value_type="discrete",
+    affects="layout",
+)}
 
 // https://drafts.csswg.org/css-flexbox/#propdef-order
 ${helpers.predefined_type(

--- a/style/properties/shorthands/position.mako.rs
+++ b/style/properties/shorthands/position.mako.rs
@@ -716,7 +716,7 @@
 
 <%helpers:shorthand
     name="place-content"
-    engines="gecko"
+    engines="gecko servo"
     sub_properties="align-content justify-content"
     spec="https://drafts.csswg.org/css-align/#propdef-place-content"
 >
@@ -771,7 +771,7 @@
 
 <%helpers:shorthand
     name="place-self"
-    engines="gecko"
+    engines="gecko servo"
     sub_properties="align-self justify-self"
     spec="https://drafts.csswg.org/css-align/#place-self-property"
 >
@@ -812,7 +812,7 @@
 
 <%helpers:shorthand
     name="place-items"
-    engines="gecko"
+    engines="gecko servo"
     sub_properties="align-items justify-items"
     spec="https://drafts.csswg.org/css-align/#place-items-property"
 >

--- a/style/style_adjuster.rs
+++ b/style/style_adjuster.rs
@@ -402,29 +402,6 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
         }
     }
 
-    /// This implements an out-of-date spec. The new spec moves the handling of
-    /// this to layout, which Gecko implements but Servo doesn't.
-    ///
-    /// See https://github.com/servo/servo/issues/15229
-    #[cfg(feature = "servo")]
-    fn adjust_for_alignment(&mut self, layout_parent_style: &ComputedValues) {
-        use crate::computed_values::align_items::T as AlignItems;
-        use crate::computed_values::align_self::T as AlignSelf;
-
-        if self.style.get_position().clone_align_self() == AlignSelf::Auto &&
-            !self.style.is_absolutely_positioned()
-        {
-            let self_align = match layout_parent_style.get_position().clone_align_items() {
-                AlignItems::Stretch => AlignSelf::Stretch,
-                AlignItems::Baseline => AlignSelf::Baseline,
-                AlignItems::FlexStart => AlignSelf::FlexStart,
-                AlignItems::FlexEnd => AlignSelf::FlexEnd,
-                AlignItems::Center => AlignSelf::Center,
-            };
-            self.style.mutate_position().set_align_self(self_align);
-        }
-    }
-
     /// The initial value of border-*-width may be changed at computed value
     /// time.
     ///
@@ -989,10 +966,6 @@ impl<'a, 'b: 'a> StyleAdjuster<'a, 'b> {
             self.adjust_for_contain_intrinsic_size();
             self.adjust_for_table_text_align();
             self.adjust_for_justify_items();
-        }
-        #[cfg(feature = "servo")]
-        {
-            self.adjust_for_alignment(layout_parent_style);
         }
         self.adjust_for_border_width();
         #[cfg(feature = "gecko")]

--- a/style/values/computed/align.rs
+++ b/style/values/computed/align.rs
@@ -10,8 +10,7 @@ use crate::values::computed::{Context, ToComputedValue};
 use crate::values::specified;
 
 pub use super::specified::{
-    AlignContent, AlignItems, AlignTracks, ContentDistribution, JustifyContent, JustifyTracks,
-    SelfAlignment,
+    AlignContent, AlignItems, ContentDistribution, JustifyContent, SelfAlignment,
 };
 pub use super::specified::{AlignSelf, JustifySelf};
 

--- a/style/values/computed/mod.rs
+++ b/style/values/computed/mod.rs
@@ -36,12 +36,9 @@ use std::cmp;
 use std::f32;
 use std::ops::{Add, Sub};
 
-#[cfg(feature = "gecko")]
 pub use self::align::{
-    AlignContent, AlignItems, AlignTracks, JustifyContent, JustifyItems, JustifyTracks,
-    SelfAlignment,
+    AlignContent, AlignItems, JustifyContent, JustifyItems, SelfAlignment,
 };
-#[cfg(feature = "gecko")]
 pub use self::align::{AlignSelf, JustifySelf};
 pub use self::angle::Angle;
 pub use self::animation::{
@@ -121,7 +118,6 @@ pub use super::specified::ViewportVariant;
 pub use super::specified::{BorderStyle, TextDecorationLine};
 pub use app_units::Au;
 
-#[cfg(feature = "gecko")]
 pub mod align;
 pub mod angle;
 pub mod animation;

--- a/style/values/specified/align.rs
+++ b/style/values/specified/align.rs
@@ -15,6 +15,7 @@ use style_traits::{CssWriter, KeywordsCollectFn, ParseError, SpecifiedValueInfo,
 #[derive(
     Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToResolvedValue, ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct AlignFlags(u8);
 bitflags! {
@@ -71,8 +72,14 @@ bitflags! {
 impl AlignFlags {
     /// Returns the enumeration value stored in the lower 5 bits.
     #[inline]
-    fn value(&self) -> Self {
+    pub fn value(&self) -> Self {
         *self & !AlignFlags::FLAG_BITS
+    }
+
+    /// Returns the flags stored in the upper 3 bits.
+    #[inline]
+    pub fn flags(&self) -> Self {
+        *self & AlignFlags::FLAG_BITS
     }
 }
 
@@ -147,8 +154,8 @@ pub enum AxisDirection {
     ToResolvedValue,
     ToShmem,
 )]
-#[repr(C)]
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[repr(C)]
 pub struct ContentDistribution {
     primary: AlignFlags,
     // FIXME(https://github.com/w3c/csswg-drafts/issues/1002): This will need to
@@ -265,6 +272,7 @@ impl ContentDistribution {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(transparent)]
 pub struct AlignContent(pub ContentDistribution);
 
@@ -288,36 +296,6 @@ impl SpecifiedValueInfo for AlignContent {
     }
 }
 
-/// Value for the `align-tracks` property.
-///
-/// <https://github.com/w3c/csswg-drafts/issues/4650>
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    Eq,
-    MallocSizeOf,
-    PartialEq,
-    SpecifiedValueInfo,
-    ToComputedValue,
-    ToCss,
-    ToResolvedValue,
-    ToShmem,
-)]
-#[repr(transparent)]
-#[css(comma)]
-pub struct AlignTracks(#[css(iterable, if_empty = "normal")] pub crate::OwnedSlice<AlignContent>);
-
-impl Parse for AlignTracks {
-    fn parse<'i, 't>(
-        context: &ParserContext,
-        input: &mut Parser<'i, 't>,
-    ) -> Result<Self, ParseError<'i>> {
-        let values = input.parse_comma_separated(|input| AlignContent::parse(context, input))?;
-        Ok(AlignTracks(values.into()))
-    }
-}
-
 /// Value for the `justify-content` property.
 ///
 /// <https://drafts.csswg.org/css-align/#propdef-justify-content>
@@ -333,6 +311,7 @@ impl Parse for AlignTracks {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(transparent)]
 pub struct JustifyContent(pub ContentDistribution);
 
@@ -355,37 +334,6 @@ impl SpecifiedValueInfo for JustifyContent {
         ContentDistribution::list_keywords(f, AxisDirection::Inline);
     }
 }
-/// Value for the `justify-tracks` property.
-///
-/// <https://github.com/w3c/csswg-drafts/issues/4650>
-#[derive(
-    Clone,
-    Debug,
-    Default,
-    Eq,
-    MallocSizeOf,
-    PartialEq,
-    SpecifiedValueInfo,
-    ToComputedValue,
-    ToCss,
-    ToResolvedValue,
-    ToShmem,
-)]
-#[repr(transparent)]
-#[css(comma)]
-pub struct JustifyTracks(
-    #[css(iterable, if_empty = "normal")] pub crate::OwnedSlice<JustifyContent>,
-);
-
-impl Parse for JustifyTracks {
-    fn parse<'i, 't>(
-        context: &ParserContext,
-        input: &mut Parser<'i, 't>,
-    ) -> Result<Self, ParseError<'i>> {
-        let values = input.parse_comma_separated(|input| JustifyContent::parse(context, input))?;
-        Ok(JustifyTracks(values.into()))
-    }
-}
 
 /// <https://drafts.csswg.org/css-align/#self-alignment>
 #[derive(
@@ -400,6 +348,7 @@ impl Parse for JustifyTracks {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(transparent)]
 pub struct SelfAlignment(pub AlignFlags);
 
@@ -472,6 +421,7 @@ impl SelfAlignment {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct AlignSelf(pub SelfAlignment);
 
@@ -510,6 +460,7 @@ impl SpecifiedValueInfo for AlignSelf {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct JustifySelf(pub SelfAlignment);
 
@@ -548,6 +499,7 @@ impl SpecifiedValueInfo for JustifySelf {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct AlignItems(pub AlignFlags);
 
@@ -600,6 +552,7 @@ impl SpecifiedValueInfo for AlignItems {
 ///
 /// <https://drafts.csswg.org/css-align/#justify-items-property>
 #[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToCss, ToResolvedValue, ToShmem)]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct JustifyItems(pub AlignFlags);
 

--- a/style/values/specified/mod.rs
+++ b/style/values/specified/mod.rs
@@ -25,10 +25,8 @@ use std::ops::Add;
 use style_traits::values::specified::AllowedNumericType;
 use style_traits::{CssWriter, ParseError, SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 
-#[cfg(feature = "gecko")]
-pub use self::align::{AlignContent, AlignItems, AlignSelf, AlignTracks, ContentDistribution};
-#[cfg(feature = "gecko")]
-pub use self::align::{JustifyContent, JustifyItems, JustifySelf, JustifyTracks, SelfAlignment};
+pub use self::align::{AlignContent, AlignItems, AlignSelf, ContentDistribution};
+pub use self::align::{JustifyContent, JustifyItems, JustifySelf, SelfAlignment};
 pub use self::angle::{AllowUnitlessZeroAngle, Angle};
 pub use self::animation::{
     AnimationComposition, AnimationDirection, AnimationFillMode, AnimationIterationCount,
@@ -113,7 +111,6 @@ pub use self::ui::CursorImage;
 pub use self::ui::{BoolInteger, Cursor, UserSelect};
 pub use super::generics::grid::GridTemplateComponent as GenericGridTemplateComponent;
 
-#[cfg(feature = "gecko")]
 pub mod align;
 pub mod angle;
 pub mod animation;


### PR DESCRIPTION
- Cherry-picked ddb7af7 from upstream
- Remove alignment style adjustment function (which should be implemented in layout anyway - implemented in servo#32686)
- Switch column-gap to being behind the flexbox flag rather than the multi-column layout flag

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
