### PR TITLE
Enable `aspect-ratio` for layout 2020

### DIFF
--- a/style/properties/longhands/position.mako.rs
+++ b/style/properties/longhands/position.mako.rs
@@ -425,7 +425,6 @@ ${helpers.predefined_type(
     "AspectRatio",
     "computed::AspectRatio::auto()",
     engines="gecko servo",
-    servo_pref="layout.legacy_layout",
     animation_value_type="ComputedValue",
     spec="https://drafts.csswg.org/css-sizing-4/#aspect-ratio",
     servo_restyle_damage="reflow",


### PR DESCRIPTION
So that we can implement it in Servo, starting with https://github.com/servo/servo/pull/32800.