### PR TITLE
Install mako on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install mako
+        run: sudo apt install python3-mako
       - name: Run Tests
         run: cargo build --features servo
         env:
@@ -29,6 +31,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+      - name: Install mako
+        run: sudo apt install python3-mako
       - name: Run Tests
         run: cargo build --release --features servo
         env:


### PR DESCRIPTION
Previous version of `main` had modifications to the `build.rs` from upstream that manually added mako to the Python path. That difference from upstream was eliminated in order to reduce the diff we have on top of Gecko's version of Stylo. This means that `mako` must be available when compiling Stylo on CI.