### PR TITLE
Add `securitypolicyviolation` to servo_atoms

### DIFF
--- a/atoms/static_atoms.txt
+++ b/atoms/static_atoms.txt
@@ -130,6 +130,7 @@ screen
 scroll-position
 scrollbar-inline-size
 search
+securitypolicyviolation
 seeked
 seeking
 select


### PR DESCRIPTION
Add `securitypolicyviolation` to servo_atoms for initial support for [servo/servo#25182](https://redirect.github.com/servo/servo/issues/25182).