### PR TITLE
Pull in D217563 and D218335 from upstream

### DIFF
--- a/atoms/static_atoms.txt
+++ b/atoms/static_atoms.txt
@@ -1,5 +1,6 @@
 -moz-content-preferred-color-scheme
 -moz-device-pixel-ratio
+-moz-fixed-pos-containing-block
 -moz-gtk-csd-close-button-position
 -moz-gtk-csd-maximize-button-position
 -moz-gtk-csd-menu-radius

--- a/style/properties/cascade.rs
+++ b/style/properties/cascade.rs
@@ -32,8 +32,6 @@ use fxhash::FxHashMap;
 use servo_arc::Arc;
 use smallvec::SmallVec;
 use std::borrow::Cow;
-#[cfg(feature = "gecko")]
-use std::mem;
 
 /// Whether we're resolving a style with the purposes of reparenting for ::first-line.
 #[derive(Copy, Clone)]
@@ -419,7 +417,8 @@ fn tweak_when_ignoring_colors(
     }
 
     // Always honor colors if forced-color-adjust is set to none.
-    #[cfg(feature = "gecko")] {
+    #[cfg(feature = "gecko")]
+    {
         let forced = context
             .builder
             .get_inherited_text()
@@ -1331,7 +1330,7 @@ impl<'b> Cascade<'b> {
                 return s;
             }
             if b < a {
-                mem::swap(&mut a, &mut b);
+                std::mem::swap(&mut a, &mut b);
                 invert_scale_factor = true;
             }
             let mut e = b - a;

--- a/style/servo/media_queries.rs
+++ b/style/servo/media_queries.rs
@@ -14,7 +14,7 @@ use crate::media_queries::MediaType;
 use crate::parser::ParserContext;
 use crate::properties::style_structs::Font;
 use crate::properties::ComputedValues;
-use crate::values::computed::{CSSPixelLength, Context, Length, LineHeight, NonNegativeLength, Resolution};
+use crate::values::computed::{CSSPixelLength, ColorScheme, Context, Length, LineHeight, NonNegativeLength, Resolution};
 use crate::values::computed::font::GenericFontFamily;
 use crate::values::specified::font::{FONT_MEDIUM_LINE_HEIGHT_PX, FONT_MEDIUM_PX};
 use crate::values::specified::ViewportVariant;
@@ -293,6 +293,10 @@ impl Device {
     /// Returns the default foreground color.
     pub fn default_color(&self) -> AbsoluteColor {
         AbsoluteColor::BLACK
+    }
+
+    pub(crate) fn is_dark_color_scheme(&self, _: &ColorScheme) -> bool {
+        false
     }
 
     /// Returns safe area insets

--- a/style/stylesheets/font_feature_values_rule.rs
+++ b/style/stylesheets/font_feature_values_rule.rs
@@ -24,8 +24,7 @@ use cssparser::{
 };
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ParseError, StyleParseErrorKind, ToCss};
-#[cfg(feature = "gecko")]
-use thin_vec::ThinVec;
+#[cfg(feature = "gecko")] use thin_vec::ThinVec;
 
 /// A @font-feature-values block declaration.
 /// It is `<ident>: <integer>+`.

--- a/style/values/specified/box.rs
+++ b/style/values/specified/box.rs
@@ -5,7 +5,6 @@
 //! Specified types for box properties.
 
 use crate::parser::{Parse, ParserContext};
-#[cfg(feature = "gecko")]
 use crate::properties::{LonghandId, PropertyDeclarationId, PropertyId};
 use crate::values::generics::box_::{
     GenericContainIntrinsicSize, GenericLineClamp, GenericPerspective, GenericVerticalAlign,
@@ -1021,6 +1020,9 @@ bitflags! {
     }
 }
 
+#[cfg(feature = "servo")]
+fn change_bits_for_longhand(_: LonghandId) -> WillChangeBits { WillChangeBits::empty() }
+
 #[cfg(feature = "gecko")]
 fn change_bits_for_longhand(longhand: LonghandId) -> WillChangeBits {
     match longhand {
@@ -1048,7 +1050,6 @@ fn change_bits_for_longhand(longhand: LonghandId) -> WillChangeBits {
     }
 }
 
-#[cfg(feature = "gecko")]
 fn change_bits_for_maybe_property(ident: &str, context: &ParserContext) -> WillChangeBits {
     let id = match PropertyId::parse_ignoring_rule_type(ident, context) {
         Ok(id) => id,
@@ -1066,7 +1067,6 @@ fn change_bits_for_maybe_property(ident: &str, context: &ParserContext) -> WillC
     }
 }
 
-#[cfg(feature = "gecko")]
 impl Parse for WillChange {
     /// auto | <animateable-feature>#
     fn parse<'i, 't>(
@@ -1663,7 +1663,7 @@ impl BreakBetween {
     /// Parse a legacy break-between value for `page-break-{before,after}`.
     ///
     /// See https://drafts.csswg.org/css-break/#page-break-properties.
-    #[cfg(feature = "gecko")]
+    #[cfg_attr(feature = "servo", allow(unused))]
     #[inline]
     pub(crate) fn parse_legacy<'i>(
         _: &ParserContext,
@@ -1684,7 +1684,7 @@ impl BreakBetween {
     /// Serialize a legacy break-between value for `page-break-*`.
     ///
     /// See https://drafts.csswg.org/css-break/#page-break-properties.
-    #[cfg(feature = "gecko")]
+    #[cfg_attr(feature = "servo", allow(unused))]
     pub(crate) fn to_css_legacy<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
     where
         W: Write,
@@ -1730,7 +1730,7 @@ impl BreakWithin {
     /// Parse a legacy break-between value for `page-break-inside`.
     ///
     /// See https://drafts.csswg.org/css-break/#page-break-properties.
-    #[cfg(feature = "gecko")]
+    #[cfg_attr(feature = "servo", allow(unused))]
     #[inline]
     pub(crate) fn parse_legacy<'i>(
         _: &ParserContext,
@@ -1748,7 +1748,7 @@ impl BreakWithin {
     /// Serialize a legacy break-between value for `page-break-inside`.
     ///
     /// See https://drafts.csswg.org/css-break/#page-break-properties.
-    #[cfg(feature = "gecko")]
+    #[cfg_attr(feature = "servo", allow(unused))]
     pub(crate) fn to_css_legacy<W>(&self, dest: &mut CssWriter<W>) -> fmt::Result
     where
         W: Write,

--- a/style/values/specified/color.rs
+++ b/style/values/specified/color.rs
@@ -138,18 +138,11 @@ pub struct LightDark {
 }
 
 impl LightDark {
-    #[cfg(feature = "gecko")]
     fn compute(&self, cx: &Context) -> ComputedColor {
         let style_color_scheme = cx.style().get_inherited_ui().clone_color_scheme();
         let dark = cx.device().is_dark_color_scheme(&style_color_scheme);
         let used = if dark { &self.dark } else { &self.light };
         used.to_computed_value(cx)
-    }
-
-    #[cfg(feature = "servo")]
-    fn compute(&self, cx: &Context) -> ComputedColor {
-        // Servo doesn't support color-scheme yet.
-        self.light.to_computed_value(cx)
     }
 
     fn parse<'i, 't>(

--- a/style/values/specified/font.rs
+++ b/style/values/specified/font.rs
@@ -689,10 +689,7 @@ impl Parse for FontFamily {
         let values =
             input.parse_comma_separated(|input| SingleFontFamily::parse(context, input))?;
         Ok(FontFamily::Values(FontFamilyList {
-            #[cfg(feature = "gecko")]
             list: crate::ArcSlice::from_iter(values.into_iter()),
-            #[cfg(feature = "servo")]
-            list: values.into_boxed_slice(),
         }))
     }
 }

--- a/style/values/specified/image.rs
+++ b/style/values/specified/image.rs
@@ -120,16 +120,6 @@ fn cross_fade_enabled() -> bool {
     false
 }
 
-#[cfg(feature = "gecko")]
-fn image_set_enabled() -> bool {
-    true
-}
-
-#[cfg(feature = "servo")]
-fn image_set_enabled() -> bool {
-    false
-}
-
 impl SpecifiedValueInfo for Gradient {
     const SUPPORTED_TYPES: u8 = CssType::GRADIENT;
 
@@ -171,9 +161,7 @@ impl<Image, Resolution> SpecifiedValueInfo for generic::ImageSet<Image, Resoluti
     const SUPPORTED_TYPES: u8 = 0;
 
     fn collect_completion_keywords(f: KeywordsCollectFn) {
-        if image_set_enabled() {
-            f(&["image-set"]);
-        }
+        f(&["image-set"]);
     }
 }
 
@@ -232,7 +220,7 @@ impl Image {
             return Ok(generic::Image::Url(url));
         }
 
-        if !flags.contains(ParseImageFlags::FORBID_IMAGE_SET) && image_set_enabled() {
+        if !flags.contains(ParseImageFlags::FORBID_IMAGE_SET) {
             if let Ok(is) =
                 input.try_parse(|input| ImageSet::parse(context, input, cors_mode, flags))
             {

--- a/style_traits/arc_slice.rs
+++ b/style_traits/arc_slice.rs
@@ -9,7 +9,7 @@ use serde::ser::{Serialize, Serializer};
 use servo_arc::ThinArc;
 use std::ops::Deref;
 use std::ptr::NonNull;
-use std::{iter, mem};
+use std::{iter, mem, hash::{Hash, Hasher}};
 
 use malloc_size_of::{MallocSizeOf, MallocSizeOfOps, MallocUnconditionalSizeOf};
 
@@ -151,6 +151,12 @@ impl<T: MallocSizeOf> MallocUnconditionalSizeOf for ArcSlice<T> {
             size += el.size_of(ops);
         }
         size
+    }
+}
+
+impl<T: Hash> Hash for ArcSlice<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        T::hash_slice(&**self, state)
     }
 }
 

--- a/style_traits/owned_slice.rs
+++ b/style_traits/owned_slice.rs
@@ -12,7 +12,7 @@ use serde::ser::{Serialize, Serializer};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
-use std::{fmt, iter, mem, slice};
+use std::{fmt, iter, mem, slice, hash::{Hash, Hasher}};
 use to_shmem::{SharedMemoryBuilder, ToShmem};
 
 /// A struct that basically replaces a `Box<[T]>`, but which cbindgen can
@@ -194,5 +194,11 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for OwnedSlice<T> {
     {
         let r = Box::<[T]>::deserialize(deserializer)?;
         Ok(r.into())
+    }
+}
+
+impl<T: Hash> Hash for OwnedSlice<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        T::hash_slice(&**self, state)
     }
 }


### PR DESCRIPTION
This pulls in two changes from upstream, so that the next time we
rebase, there will not be merge conflicts:

- https://phabricator.services.mozilla.com/D217563
- https://phabricator.services.mozilla.com/D218335

The reason we need to do this is that the first is an upstreaming of
code we have downstream, but with changes. This just ports these changes
to upstream.
