### PR TITLE
Update markup5ever.

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -68,7 +68,7 @@ lazy_static = "1"
 log = "0.4"
 malloc_size_of = { path = "../malloc_size_of" }
 malloc_size_of_derive = "0.1"
-markup5ever = { version = "0.12", optional = true }
+markup5ever = { version = "0.13", optional = true }
 matches = "0.1"
 mime = { version = "0.3.13", optional = true }
 num_cpus = {version = "1.1.0"}


### PR DESCRIPTION
This is needed to upgrade html5ever in Servo.