### PR TITLE
Remove dependency on `time`

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -19,7 +19,6 @@ servo = [
     "serde",
     "serde_bytes",
     "string_cache",
-    "time",
     "url",
     "uuid",
     "webrender_api",
@@ -46,7 +45,6 @@ smallbitvec = "2.3.0"
 smallvec = "1.13"
 string_cache = { version = "0.8", optional = true }
 thin-vec = { version = "0.2.13" }
-time = { version = "0.1.41", optional = true }
 tokio = { version = "1", features = ["sync"] }
 url = { version = "2.5", features = ["serde"], optional = true }
 uuid = { version = "1.7.0", optional = true }

--- a/malloc_size_of/lib.rs
+++ b/malloc_size_of/lib.rs
@@ -69,8 +69,6 @@ extern crate smallbitvec;
 extern crate smallvec;
 #[cfg(feature = "servo")]
 extern crate string_cache;
-#[cfg(feature = "servo")]
-extern crate time;
 #[cfg(feature = "url")]
 extern crate url;
 #[cfg(feature = "servo")]
@@ -945,10 +943,6 @@ impl MallocSizeOf for xml5ever::QualName {
     }
 }
 
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(time::Duration);
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(time::Tm);
 #[cfg(feature = "servo")]
 malloc_size_of_is_0!(std::time::Duration);
 #[cfg(feature = "servo")]

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -93,7 +93,6 @@ style_derive = {path = "../style_derive"}
 style_traits = {path = "../style_traits"}
 to_shmem = {path = "../to_shmem"}
 to_shmem_derive = {path = "../to_shmem_derive"}
-time = "0.1"
 thin-vec = "0.2.1"
 uluru = "3.0"
 unicode-bidi = { version = "0.3", default-features = false }

--- a/style/driver.rs
+++ b/style/driver.rs
@@ -14,6 +14,7 @@ use crate::parallel;
 use crate::scoped_tls::ScopedTLS;
 use crate::traversal::{DomTraversal, PerLevelTraversalData, PreTraverseToken};
 use std::collections::VecDeque;
+use std::time::Instant;
 
 #[cfg(feature = "servo")]
 fn should_report_statistics() -> bool {
@@ -102,7 +103,7 @@ where
     let report_stats = should_report_statistics();
     let dump_stats = traversal.shared_context().options.dump_style_statistics;
     let start_time = if dump_stats {
-        Some(time::precise_time_s())
+        Some(Instant::now())
     } else {
         None
     };


### PR DESCRIPTION
This is no longer needed and the version of `time` used is very old.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
