### PR TITLE
Remove unused `size_of_test` dependency from `selectors` and `style_traits`

### DIFF
--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -26,7 +26,6 @@ log = "0.4"
 phf = "0.11"
 precomputed-hash = "0.1"
 servo_arc = { version = "0.2", path = "../servo_arc" }
-size_of_test = { path = "../size_of_test" }
 smallvec = "1.0"
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -25,7 +25,6 @@ selectors = { path = "../selectors" }
 serde = "1.0"
 servo_arc = { path = "../servo_arc" }
 servo_atoms = { path = "../atoms", optional = true }
-size_of_test = { path = "../size_of_test" }
 thin-vec = "0.2"
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }


### PR DESCRIPTION
Both of these crates specified `size_of_test` as a dependency but were not actually using it, so I have removed the crate from the dependency list.

This change has already been made upstream so this reduces the diff.

---

With this change, the `size_of_test` crate is not used at all by crates in this repository. The `style` crate has an identical `size_of_test` macro, but it defines it itself. However, some Servo modules are currently using this crate (from this repository) so we can't delete it entirely. However I think we should consider:

- Moving it to the `servo/servo` repo.
- OR moving it to it's own repo, publishing it on crates.io and consuming it from there.

It's pretty trivial so maintenance should be easy either way.