### PR TITLE
Add Cargo.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /_filtered/
 /target/
 /style/properties/__pycache__/
+Cargo.lock


### PR DESCRIPTION
We don't have `Cargo.lock` committed, so we should ignore it. Currently it keeps showing up as an untracked file which makes it hard to avoid accidentally committing it as part of unrelated changes. `.gitignore` is currently not upstream but is part of the "Initial downstream commit".