### PR TITLE
Expose `-moz-center-or-inherit` for Servo

### DIFF
--- a/style/values/specified/text.rs
+++ b/style/values/specified/text.rs
@@ -460,7 +460,6 @@ pub enum TextAlign {
     /// Since selectors can't depend on the ancestor styles, we implement it with a
     /// magic value that computes to the right thing. Since this is an
     /// implementation detail, it shouldn't be exposed to web content.
-    #[cfg(feature = "gecko")]
     #[parse(condition = "ParserContext::chrome_rules_enabled")]
     MozCenterOrInherit,
 }
@@ -496,7 +495,6 @@ impl ToComputedValue for TextAlign {
                     _ => parent,
                 }
             },
-            #[cfg(feature = "gecko")]
             TextAlign::MozCenterOrInherit => {
                 let parent = _context
                     .builder


### PR DESCRIPTION
This is used to implement the following HTML specification rule about
`<th>` elements:

 > User agents are expected to have a rule in their user agent style sheet
 > that matches th elements that have a parent node whose computed value
 > for the 'text-align' property is its initial value, whose declaration
 > block consists of just a single declaration that sets the 'text-align'
 > property to the value 'center'.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
