### PR TITLE
Derive MallocSizeOf for ComputedValueFlags

### DIFF
--- a/style/properties/computed_value_flags.rs
+++ b/style/properties/computed_value_flags.rs
@@ -4,16 +4,19 @@
 
 //! Misc information about a given computed style.
 
+/// Misc information about a given computed style.
+///
+/// All flags are currently inherited for text, pseudo elements, and
+/// anonymous boxes, see StyleBuilder::for_inheritance and its callsites.
+/// If we ever want to add some flags that shouldn't inherit for them,
+/// we might want to add a function to handle this.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+pub struct ComputedValueFlags(u32);
+
 bitflags! {
-    /// Misc information about a given computed style.
-    ///
-    /// All flags are currently inherited for text, pseudo elements, and
-    /// anonymous boxes, see StyleBuilder::for_inheritance and its callsites.
-    /// If we ever want to add some flags that shouldn't inherit for them,
-    /// we might want to add a function to handle this.
-    #[repr(C)]
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct ComputedValueFlags: u32 {
+    impl ComputedValueFlags: u32 {
         /// Whether the style or any of the ancestors has a text-decoration-line
         /// property that should get propagated to descendants.
         ///

--- a/style/stylist.rs
+++ b/style/stylist.rs
@@ -570,7 +570,6 @@ pub struct Stylist {
     initial_values_for_custom_properties: ComputedCustomProperties,
 
     /// Flags set from computing registered custom property initial values.
-    #[cfg_attr(feature = "servo", ignore_malloc_size_of = "missing malloc_size_of")]
     initial_values_for_custom_properties_flags: ComputedValueFlags,
 
     /// The total number of times the stylist has been rebuilt.


### PR DESCRIPTION
And then remove ignore_malloc_size_of in Stylist.