### PR TITLE
Enable `stretch` keyword

### DIFF
--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -24,6 +24,9 @@ macro_rules! pref {
     ("layout.css.basic-shape-xywh.enabled") => {
         true
     };
+    ("layout.css.stretch-size-keyword.enabled") => {
+        true
+    };
     ($string:literal) => {
         false
     };


### PR DESCRIPTION
In #79 we forgot to set the relevant pref to true. We will be adding support for these sizing keywords in Servo, so better enable it so that we can test that it works well.