### PR TITLE
Allow parsing `transition-behavior` value in `transition` shorthand

### DIFF
--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -27,6 +27,9 @@ macro_rules! pref {
     ("layout.css.stretch-size-keyword.enabled") => {
         true
     };
+    ("layout.css.transition-behavior.enabled") => {
+        true
+    };
     ($string:literal) => {
         false
     };


### PR DESCRIPTION
In #84 I forgot to enable the pref, so the shorthand was still rejecting `transition-behavior` values.