### PR TITLE
Add `stylo_taffy` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "style_derive",
     "style_static_prefs",
     "style_traits",
+    "stylo_taffy",
     "to_shmem",
     "to_shmem_derive",
 ]

--- a/stylo_taffy/Cargo.toml
+++ b/stylo_taffy/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stylo_taffy"
+version = "0.1.0"
+license = "MIT OR APACHE 2.0"
+description = "Interop crate for the Stylo and Taffy crates"
+keywords = ["css", "layout"]
+categories = ["gui"]
+edition = "2021"
+repository = "https://github.com/servo/stylo"
+
+[features]
+default = ["std", "block", "flexbox", "grid"]
+std = ["taffy/std"]
+block = ["taffy/block_layout"]
+flexbox = ["taffy/flexbox"]
+grid = ["taffy/grid"]
+
+[dependencies]
+taffy = { version = "0.6.1", default-features = false, features = ["std"] }
+style = { path = "../style", features = ["servo"] }

--- a/stylo_taffy/LICENSE-APACHE
+++ b/stylo_taffy/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/stylo_taffy/LICENSE-MIT
+++ b/stylo_taffy/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/stylo_taffy/src/convert.rs
+++ b/stylo_taffy/src/convert.rs
@@ -1,0 +1,555 @@
+//! Type conversion functions for individual types
+
+/// Private module of type aliases so we can refer to stylo types with nicer names
+///
+/// We ignore unused imports unless all feature flags are enabled so that we don't have to do fine-grained conditional imports
+#[cfg_attr(
+    not(all(feature = "grid", feature = "flexbox", feature = "block")),
+    allow(unused_import)
+)]
+mod stylo {
+    pub(crate) use style::computed_values::flex_direction::T as FlexDirection;
+    pub(crate) use style::computed_values::flex_wrap::T as FlexWrap;
+    pub(crate) use style::computed_values::grid_auto_flow::T as GridAutoFlow;
+    pub(crate) use style::properties::generated::longhands::box_sizing::computed_value::T as BoxSizing;
+    pub(crate) use style::properties::longhands::aspect_ratio::computed_value::T as AspectRatio;
+    pub(crate) use style::properties::longhands::position::computed_value::T as Position;
+    pub(crate) use style::properties::ComputedValues;
+    pub(crate) use style::values::computed::text::TextAlign;
+    pub(crate) use style::values::computed::Percentage;
+    pub(crate) use style::values::computed::{
+        GridLine, GridTemplateComponent, ImplicitGridTracks, LengthPercentage,
+    };
+    pub(crate) use style::values::generics::flex::GenericFlexBasis;
+    pub(crate) use style::values::generics::grid::{
+        RepeatCount, TrackBreadth, TrackListValue, TrackSize,
+    };
+    pub(crate) use style::values::generics::length::GenericMargin;
+    pub(crate) use style::values::generics::length::{
+        GenericLengthPercentageOrNormal, GenericMaxSize, GenericSize,
+    };
+    pub(crate) use style::values::generics::position::Inset as GenericInset;
+    pub(crate) use style::values::generics::position::PreferredRatio;
+    pub(crate) use style::values::generics::NonNegative;
+    pub(crate) use style::values::specified::align::{AlignFlags, ContentDistribution};
+    pub(crate) use style::values::specified::box_::{
+        Display, DisplayInside, DisplayOutside, Overflow,
+    };
+    pub(crate) use style::values::specified::GenericGridTemplateComponent;
+    pub(crate) type MarginVal = GenericMargin<LengthPercentage>;
+    pub(crate) type InsetVal = GenericInset<Percentage, LengthPercentage>;
+    pub(crate) type Size = GenericSize<NonNegative<LengthPercentage>>;
+    pub(crate) type MaxSize = GenericMaxSize<NonNegative<LengthPercentage>>;
+    pub(crate) type FlexBasis = GenericFlexBasis<Size>;
+    pub(crate) type Gap = GenericLengthPercentageOrNormal<NonNegative<LengthPercentage>>;
+}
+
+#[inline]
+pub fn length_percentage(val: &stylo::LengthPercentage) -> taffy::LengthPercentage {
+    if let Some(length) = val.to_length() {
+        taffy::LengthPercentage::Length(length.px())
+    } else if let Some(val) = val.to_percentage() {
+        taffy::LengthPercentage::Percent(val.0)
+    } else {
+        // TODO: Support calc
+        taffy::LengthPercentage::Percent(0.0)
+    }
+}
+
+#[inline]
+pub fn dimension(val: &stylo::Size) -> taffy::Dimension {
+    match val {
+        stylo::Size::LengthPercentage(val) => length_percentage(&val.0).into(),
+        stylo::Size::Auto => taffy::Dimension::Auto,
+
+        // TODO: implement other values in Taffy
+        stylo::Size::MaxContent => taffy::Dimension::Auto,
+        stylo::Size::MinContent => taffy::Dimension::Auto,
+        stylo::Size::FitContent => taffy::Dimension::Auto,
+        stylo::Size::Stretch => taffy::Dimension::Auto,
+
+        // Anchor positioning will be flagged off for time being
+        stylo::Size::AnchorSizeFunction(_) => unreachable!(),
+    }
+}
+
+#[inline]
+pub fn max_size_dimension(val: &stylo::MaxSize) -> taffy::Dimension {
+    match val {
+        stylo::MaxSize::LengthPercentage(val) => length_percentage(&val.0).into(),
+        stylo::MaxSize::None => taffy::Dimension::Auto,
+
+        // TODO: implement other values in Taffy
+        stylo::MaxSize::MaxContent => taffy::Dimension::Auto,
+        stylo::MaxSize::MinContent => taffy::Dimension::Auto,
+        stylo::MaxSize::FitContent => taffy::Dimension::Auto,
+        stylo::MaxSize::Stretch => taffy::Dimension::Auto,
+
+        // Anchor positioning will be flagged off for time being
+        stylo::MaxSize::AnchorSizeFunction(_) => unreachable!(),
+    }
+}
+
+#[inline]
+pub fn margin(val: &stylo::MarginVal) -> taffy::LengthPercentageAuto {
+    match val {
+        stylo::MarginVal::Auto => taffy::LengthPercentageAuto::Auto,
+        stylo::MarginVal::LengthPercentage(val) => length_percentage(val).into(),
+
+        // Anchor positioning will be flagged off for time being
+        stylo::MarginVal::AnchorSizeFunction(_) => unreachable!(),
+    }
+}
+
+#[inline]
+pub fn inset(val: &stylo::InsetVal) -> taffy::LengthPercentageAuto {
+    match val {
+        stylo::InsetVal::Auto => taffy::LengthPercentageAuto::Auto,
+        stylo::InsetVal::LengthPercentage(val) => length_percentage(val).into(),
+
+        // Anchor positioning will be flagged off for time being
+        stylo::InsetVal::AnchorSizeFunction(_) => unreachable!(),
+        stylo::InsetVal::AnchorFunction(_) => unreachable!(),
+    }
+}
+
+#[inline]
+pub fn is_block(input: stylo::Display) -> bool {
+    matches!(input.outside(), stylo::DisplayOutside::Block) &&
+        matches!(
+            input.inside(),
+            stylo::DisplayInside::Flow | stylo::DisplayInside::FlowRoot
+        )
+}
+
+#[inline]
+pub fn is_table(input: stylo::Display) -> bool {
+    matches!(input.inside(), stylo::DisplayInside::Table)
+}
+
+#[inline]
+pub fn display(input: stylo::Display) -> taffy::Display {
+    let mut display = match input.inside() {
+        stylo::DisplayInside::None => taffy::Display::None,
+        stylo::DisplayInside::Flex => taffy::Display::Flex,
+        stylo::DisplayInside::Grid => taffy::Display::Grid,
+        stylo::DisplayInside::Flow => taffy::Display::Block,
+        stylo::DisplayInside::FlowRoot => taffy::Display::Block,
+        // TODO: Support grid layout in servo configuration of stylo
+        // TODO: Support display:contents in Taffy
+        // TODO: Support table layout in Taffy
+        stylo::DisplayInside::Table => taffy::Display::Grid,
+        _ => {
+            // println!("FALLBACK {:?} {:?}", input.inside(), input.outside());
+            taffy::Display::Block
+        },
+    };
+
+    match input.outside() {
+        // This is probably redundant as I suspect display.inside() is always None
+        // when display.outside() is None.
+        stylo::DisplayOutside::None => display = taffy::Display::None,
+
+        // TODO: Support flow and table layout
+        stylo::DisplayOutside::Inline => {},
+        stylo::DisplayOutside::Block => {},
+        stylo::DisplayOutside::TableCaption => {},
+        stylo::DisplayOutside::InternalTable => {},
+    };
+
+    display
+}
+
+#[inline]
+pub fn box_generation_mode(input: stylo::Display) -> taffy::BoxGenerationMode {
+    match input.inside() {
+        stylo::DisplayInside::None => taffy::BoxGenerationMode::None,
+        // stylo::DisplayInside::Contents => display = taffy::BoxGenerationMode::Contents,
+        _ => taffy::BoxGenerationMode::Normal,
+    }
+}
+
+#[inline]
+pub fn box_sizing(input: stylo::BoxSizing) -> taffy::BoxSizing {
+    match input {
+        stylo::BoxSizing::BorderBox => taffy::BoxSizing::BorderBox,
+        stylo::BoxSizing::ContentBox => taffy::BoxSizing::ContentBox,
+    }
+}
+
+#[inline]
+pub fn position(input: stylo::Position) -> taffy::Position {
+    match input {
+        // TODO: support position:static
+        stylo::Position::Relative => taffy::Position::Relative,
+        stylo::Position::Static => taffy::Position::Relative,
+
+        // TODO: support position:fixed and sticky
+        stylo::Position::Absolute => taffy::Position::Absolute,
+        stylo::Position::Fixed => taffy::Position::Absolute,
+        stylo::Position::Sticky => taffy::Position::Absolute,
+    }
+}
+
+#[inline]
+pub fn overflow(input: stylo::Overflow) -> taffy::Overflow {
+    // TODO: Enable Overflow::Clip in servo configuration of stylo
+    match input {
+        stylo::Overflow::Visible => taffy::Overflow::Visible,
+        stylo::Overflow::Hidden => taffy::Overflow::Hidden,
+        stylo::Overflow::Scroll => taffy::Overflow::Scroll,
+        // TODO: Support Overflow::Auto in Taffy
+        stylo::Overflow::Auto => taffy::Overflow::Scroll,
+    }
+}
+
+#[inline]
+pub fn aspect_ratio(input: stylo::AspectRatio) -> Option<f32> {
+    match input.ratio {
+        stylo::PreferredRatio::None => None,
+        stylo::PreferredRatio::Ratio(val) => Some(val.0 .0 / val.1 .0),
+    }
+}
+
+#[inline]
+pub fn content_alignment(input: stylo::ContentDistribution) -> Option<taffy::AlignContent> {
+    match input.primary().value() {
+        stylo::AlignFlags::NORMAL => None,
+        stylo::AlignFlags::AUTO => None,
+        stylo::AlignFlags::START => Some(taffy::AlignContent::Start),
+        stylo::AlignFlags::END => Some(taffy::AlignContent::End),
+        stylo::AlignFlags::FLEX_START => Some(taffy::AlignContent::FlexStart),
+        stylo::AlignFlags::STRETCH => Some(taffy::AlignContent::Stretch),
+        stylo::AlignFlags::FLEX_END => Some(taffy::AlignContent::FlexEnd),
+        stylo::AlignFlags::CENTER => Some(taffy::AlignContent::Center),
+        stylo::AlignFlags::SPACE_BETWEEN => Some(taffy::AlignContent::SpaceBetween),
+        stylo::AlignFlags::SPACE_AROUND => Some(taffy::AlignContent::SpaceAround),
+        stylo::AlignFlags::SPACE_EVENLY => Some(taffy::AlignContent::SpaceEvenly),
+        // Should never be hit. But no real reason to panic here.
+        _ => None,
+    }
+}
+
+#[inline]
+pub fn item_alignment(input: stylo::AlignFlags) -> Option<taffy::AlignItems> {
+    match input.value() {
+        stylo::AlignFlags::NORMAL => None,
+        stylo::AlignFlags::AUTO => None,
+        stylo::AlignFlags::STRETCH => Some(taffy::AlignItems::Stretch),
+        stylo::AlignFlags::FLEX_START => Some(taffy::AlignItems::FlexStart),
+        stylo::AlignFlags::FLEX_END => Some(taffy::AlignItems::FlexEnd),
+        stylo::AlignFlags::START => Some(taffy::AlignItems::Start),
+        stylo::AlignFlags::END => Some(taffy::AlignItems::End),
+        stylo::AlignFlags::CENTER => Some(taffy::AlignItems::Center),
+        stylo::AlignFlags::BASELINE => Some(taffy::AlignItems::Baseline),
+        // Should never be hit. But no real reason to panic here.
+        _ => None,
+    }
+}
+
+#[inline]
+pub fn gap(input: &stylo::Gap) -> taffy::LengthPercentage {
+    match input {
+        // For Flexbox and CSS Grid the "normal" value is 0px. This may need to be updated
+        // if we ever implement multi-column layout.
+        stylo::Gap::Normal => taffy::LengthPercentage::Length(0.0),
+        stylo::Gap::LengthPercentage(val) => length_percentage(&val.0),
+    }
+}
+
+#[inline]
+#[cfg(feature = "block")]
+pub(crate) fn text_align(input: stylo::TextAlign) -> taffy::TextAlign {
+    match input {
+        stylo::TextAlign::MozLeft => taffy::TextAlign::LegacyLeft,
+        stylo::TextAlign::MozRight => taffy::TextAlign::LegacyRight,
+        stylo::TextAlign::MozCenter => taffy::TextAlign::LegacyCenter,
+        _ => taffy::TextAlign::Auto,
+    }
+}
+
+#[inline]
+#[cfg(feature = "flexbox")]
+pub fn flex_basis(input: &stylo::FlexBasis) -> taffy::Dimension {
+    // TODO: Support flex-basis: content in Taffy
+    match input {
+        stylo::FlexBasis::Content => taffy::Dimension::Auto,
+        stylo::FlexBasis::Size(size) => dimension(size),
+    }
+}
+
+#[inline]
+#[cfg(feature = "flexbox")]
+pub fn flex_direction(input: stylo::FlexDirection) -> taffy::FlexDirection {
+    match input {
+        stylo::FlexDirection::Row => taffy::FlexDirection::Row,
+        stylo::FlexDirection::RowReverse => taffy::FlexDirection::RowReverse,
+        stylo::FlexDirection::Column => taffy::FlexDirection::Column,
+        stylo::FlexDirection::ColumnReverse => taffy::FlexDirection::ColumnReverse,
+    }
+}
+
+#[inline]
+#[cfg(feature = "flexbox")]
+pub fn flex_wrap(input: stylo::FlexWrap) -> taffy::FlexWrap {
+    match input {
+        stylo::FlexWrap::Wrap => taffy::FlexWrap::Wrap,
+        stylo::FlexWrap::WrapReverse => taffy::FlexWrap::WrapReverse,
+        stylo::FlexWrap::Nowrap => taffy::FlexWrap::NoWrap,
+    }
+}
+
+// CSS Grid styles
+// ===============
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn grid_auto_flow(input: stylo::GridAutoFlow) -> taffy::GridAutoFlow {
+    let is_row = input.contains(stylo::GridAutoFlow::ROW);
+    let is_dense = input.contains(stylo::GridAutoFlow::DENSE);
+
+    match (is_row, is_dense) {
+        (true, false) => taffy::GridAutoFlow::Row,
+        (true, true) => taffy::GridAutoFlow::RowDense,
+        (false, false) => taffy::GridAutoFlow::Column,
+        (false, true) => taffy::GridAutoFlow::ColumnDense,
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn grid_line(input: &stylo::GridLine) -> taffy::GridPlacement {
+    if input.is_auto() {
+        taffy::GridPlacement::Auto
+    } else if input.is_span {
+        taffy::style_helpers::span(input.line_num.try_into().unwrap())
+    } else if input.line_num == 0 {
+        taffy::GridPlacement::Auto
+    } else {
+        taffy::style_helpers::line(input.line_num.try_into().unwrap())
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn grid_template_tracks(
+    input: &stylo::GridTemplateComponent,
+) -> Vec<taffy::TrackSizingFunction> {
+    match input {
+        stylo::GenericGridTemplateComponent::None => Vec::new(),
+        stylo::GenericGridTemplateComponent::TrackList(list) => list
+            .values
+            .iter()
+            .map(|track| match track {
+                stylo::TrackListValue::TrackSize(size) => {
+                    taffy::TrackSizingFunction::Single(track_size(size))
+                },
+                stylo::TrackListValue::TrackRepeat(repeat) => taffy::TrackSizingFunction::Repeat(
+                    track_repeat(repeat.count),
+                    repeat.track_sizes.iter().map(track_size).collect(),
+                ),
+            })
+            .collect(),
+
+        // TODO: Implement subgrid and masonry
+        stylo::GenericGridTemplateComponent::Subgrid(_) => Vec::new(),
+        stylo::GenericGridTemplateComponent::Masonry => Vec::new(),
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn grid_auto_tracks(
+    input: &stylo::ImplicitGridTracks,
+) -> Vec<taffy::NonRepeatedTrackSizingFunction> {
+    input.0.iter().map(track_size).collect()
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn track_repeat(input: stylo::RepeatCount<i32>) -> taffy::GridTrackRepetition {
+    match input {
+        stylo::RepeatCount::Number(val) => {
+            taffy::GridTrackRepetition::Count(val.try_into().unwrap())
+        },
+        stylo::RepeatCount::AutoFill => taffy::GridTrackRepetition::AutoFill,
+        stylo::RepeatCount::AutoFit => taffy::GridTrackRepetition::AutoFit,
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn track_size(
+    input: &stylo::TrackSize<stylo::LengthPercentage>,
+) -> taffy::NonRepeatedTrackSizingFunction {
+    match input {
+        stylo::TrackSize::Breadth(breadth) => taffy::MinMax {
+            min: min_track(breadth),
+            max: max_track(breadth),
+        },
+        stylo::TrackSize::Minmax(min, max) => taffy::MinMax {
+            min: min_track(min),
+            max: max_track(max),
+        },
+        stylo::TrackSize::FitContent(limit) => taffy::MinMax {
+            min: taffy::MinTrackSizingFunction::Auto,
+            max: taffy::MaxTrackSizingFunction::FitContent(match limit {
+                stylo::TrackBreadth::Breadth(lp) => length_percentage(lp),
+
+                // Are these valid? Taffy doesn't support this in any case
+                stylo::TrackBreadth::Fr(_) => unreachable!(),
+                stylo::TrackBreadth::Auto => unreachable!(),
+                stylo::TrackBreadth::MinContent => unreachable!(),
+                stylo::TrackBreadth::MaxContent => unreachable!(),
+            }),
+        },
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn min_track(
+    input: &stylo::TrackBreadth<stylo::LengthPercentage>,
+) -> taffy::MinTrackSizingFunction {
+    match input {
+        stylo::TrackBreadth::Breadth(lp) => {
+            taffy::MinTrackSizingFunction::Fixed(length_percentage(lp))
+        },
+        stylo::TrackBreadth::Fr(_) => taffy::MinTrackSizingFunction::Auto,
+        stylo::TrackBreadth::Auto => taffy::MinTrackSizingFunction::Auto,
+        stylo::TrackBreadth::MinContent => taffy::MinTrackSizingFunction::MinContent,
+        stylo::TrackBreadth::MaxContent => taffy::MinTrackSizingFunction::MaxContent,
+    }
+}
+
+#[inline]
+#[cfg(feature = "grid")]
+pub fn max_track(
+    input: &stylo::TrackBreadth<stylo::LengthPercentage>,
+) -> taffy::MaxTrackSizingFunction {
+    match input {
+        stylo::TrackBreadth::Breadth(lp) => {
+            taffy::MaxTrackSizingFunction::Fixed(length_percentage(lp))
+        },
+        stylo::TrackBreadth::Fr(val) => taffy::MaxTrackSizingFunction::Fraction(*val),
+        stylo::TrackBreadth::Auto => taffy::MaxTrackSizingFunction::Auto,
+        stylo::TrackBreadth::MinContent => taffy::MaxTrackSizingFunction::MinContent,
+        stylo::TrackBreadth::MaxContent => taffy::MaxTrackSizingFunction::MaxContent,
+    }
+}
+
+pub fn to_taffy_style(style: &stylo::ComputedValues) -> taffy::Style {
+    let display = style.clone_display();
+    let pos = style.get_position();
+    let margin = style.get_margin();
+    let padding = style.get_padding();
+    let border = style.get_border();
+
+    taffy::Style {
+        display: self::display(display),
+        box_sizing: self::box_sizing(style.clone_box_sizing()),
+        item_is_table: display.inside() == stylo::DisplayInside::Table,
+        position: self::position(style.clone_position()),
+        overflow: taffy::Point {
+            x: self::overflow(style.clone_overflow_x()),
+            y: self::overflow(style.clone_overflow_y()),
+        },
+        scrollbar_width: 0.0,
+
+        size: taffy::Size {
+            width: self::dimension(&pos.width),
+            height: self::dimension(&pos.height),
+        },
+        min_size: taffy::Size {
+            width: self::dimension(&pos.min_width),
+            height: self::dimension(&pos.min_height),
+        },
+        max_size: taffy::Size {
+            width: self::max_size_dimension(&pos.max_width),
+            height: self::max_size_dimension(&pos.max_height),
+        },
+        aspect_ratio: self::aspect_ratio(pos.aspect_ratio),
+
+        inset: taffy::Rect {
+            left: self::inset(&pos.left),
+            right: self::inset(&pos.right),
+            top: self::inset(&pos.top),
+            bottom: self::inset(&pos.bottom),
+        },
+        margin: taffy::Rect {
+            left: self::margin(&margin.margin_left),
+            right: self::margin(&margin.margin_right),
+            top: self::margin(&margin.margin_top),
+            bottom: self::margin(&margin.margin_bottom),
+        },
+        padding: taffy::Rect {
+            left: self::length_percentage(&padding.padding_left.0),
+            right: self::length_percentage(&padding.padding_right.0),
+            top: self::length_percentage(&padding.padding_top.0),
+            bottom: self::length_percentage(&padding.padding_bottom.0),
+        },
+        border: taffy::Rect {
+            left: taffy::LengthPercentage::Length(border.border_left_width.to_f32_px()),
+            right: taffy::LengthPercentage::Length(border.border_right_width.to_f32_px()),
+            top: taffy::LengthPercentage::Length(border.border_top_width.to_f32_px()),
+            bottom: taffy::LengthPercentage::Length(border.border_bottom_width.to_f32_px()),
+        },
+
+        // Gap
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        gap: taffy::Size {
+            width: self::gap(&pos.column_gap),
+            height: self::gap(&pos.row_gap),
+        },
+
+        // Alignment
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        align_content: self::content_alignment(pos.align_content.0),
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        justify_content: self::content_alignment(pos.justify_content.0),
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        align_items: self::item_alignment(pos.align_items.0),
+        #[cfg(any(feature = "flexbox", feature = "grid"))]
+        align_self: self::item_alignment((pos.align_self.0).0),
+        #[cfg(feature = "grid")]
+        justify_items: self::item_alignment(pos.justify_items.computed.0),
+        #[cfg(feature = "grid")]
+        justify_self: self::item_alignment((pos.justify_self.0).0),
+        #[cfg(feature = "block")]
+        text_align: self::text_align(style.clone_text_align()),
+
+        // Flexbox
+        #[cfg(feature = "flexbox")]
+        flex_direction: self::flex_direction(pos.flex_direction),
+        #[cfg(feature = "flexbox")]
+        flex_wrap: self::flex_wrap(pos.flex_wrap),
+        #[cfg(feature = "flexbox")]
+        flex_grow: pos.flex_grow.0,
+        #[cfg(feature = "flexbox")]
+        flex_shrink: pos.flex_shrink.0,
+        #[cfg(feature = "flexbox")]
+        flex_basis: self::flex_basis(&pos.flex_basis),
+
+        // Grid
+        #[cfg(feature = "grid")]
+        grid_auto_flow: self::grid_auto_flow(pos.grid_auto_flow),
+        #[cfg(feature = "grid")]
+        grid_template_rows: self::grid_template_tracks(&pos.grid_template_rows),
+        #[cfg(feature = "grid")]
+        grid_template_columns: self::grid_template_tracks(&pos.grid_template_columns),
+        #[cfg(feature = "grid")]
+        grid_auto_rows: self::grid_auto_tracks(&pos.grid_auto_rows),
+        #[cfg(feature = "grid")]
+        grid_auto_columns: self::grid_auto_tracks(&pos.grid_auto_columns),
+        #[cfg(feature = "grid")]
+        grid_row: taffy::Line {
+            start: self::grid_line(&pos.grid_row_start),
+            end: self::grid_line(&pos.grid_row_end),
+        },
+        #[cfg(feature = "grid")]
+        grid_column: taffy::Line {
+            start: self::grid_line(&pos.grid_column_start),
+            end: self::grid_line(&pos.grid_column_end),
+        },
+    }
+}

--- a/stylo_taffy/src/lib.rs
+++ b/stylo_taffy/src/lib.rs
@@ -1,0 +1,315 @@
+use std::ops::Deref;
+use style::properties::ComputedValues;
+
+pub mod convert;
+pub use convert::to_taffy_style;
+
+/// A wrapper struct for anything that Deref's to a [`stylo::ComputedValues`], which implements Taffy's layout traits
+/// and can used with Taffy's layout algorithms.
+pub struct TaffyStyloStyle<T: Deref<Target = ComputedValues>>(pub T);
+
+// Deref<stylo::ComputedValues> impl
+impl<T: Deref<Target = ComputedValues>> From<T> for TaffyStyloStyle<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+// Into<taffy::Style> impl
+impl<T: Deref<Target = ComputedValues>> Into<taffy::Style> for TaffyStyloStyle<T> {
+    fn into(self) -> taffy::Style {
+        convert::to_taffy_style(&self.0)
+    }
+}
+
+// CoreStyle impl
+impl<T: Deref<Target = ComputedValues>> taffy::CoreStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn box_generation_mode(&self) -> taffy::BoxGenerationMode {
+        convert::box_generation_mode(self.0.get_box().display)
+    }
+
+    #[inline]
+    fn is_block(&self) -> bool {
+        convert::is_block(self.0.get_box().display)
+    }
+
+    #[inline]
+    fn box_sizing(&self) -> taffy::BoxSizing {
+        convert::box_sizing(self.0.get_position().box_sizing)
+    }
+
+    #[inline]
+    fn overflow(&self) -> taffy::Point<taffy::Overflow> {
+        let box_styles = self.0.get_box();
+        taffy::Point {
+            x: convert::overflow(box_styles.overflow_x),
+            y: convert::overflow(box_styles.overflow_y),
+        }
+    }
+
+    #[inline]
+    fn scrollbar_width(&self) -> f32 {
+        0.0
+    }
+
+    #[inline]
+    fn position(&self) -> taffy::Position {
+        convert::position(self.0.get_box().position)
+    }
+
+    #[inline]
+    fn inset(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
+        let position_styles = self.0.get_position();
+        taffy::Rect {
+            left: convert::inset(&position_styles.left),
+            right: convert::inset(&position_styles.right),
+            top: convert::inset(&position_styles.top),
+            bottom: convert::inset(&position_styles.bottom),
+        }
+    }
+
+    #[inline]
+    fn size(&self) -> taffy::Size<taffy::Dimension> {
+        let position_styles = self.0.get_position();
+        taffy::Size {
+            width: convert::dimension(&position_styles.width),
+            height: convert::dimension(&position_styles.height),
+        }
+    }
+
+    #[inline]
+    fn min_size(&self) -> taffy::Size<taffy::Dimension> {
+        let position_styles = self.0.get_position();
+        taffy::Size {
+            width: convert::dimension(&position_styles.min_width),
+            height: convert::dimension(&position_styles.min_height),
+        }
+    }
+
+    #[inline]
+    fn max_size(&self) -> taffy::Size<taffy::Dimension> {
+        let position_styles = self.0.get_position();
+        taffy::Size {
+            width: convert::max_size_dimension(&position_styles.max_width),
+            height: convert::max_size_dimension(&position_styles.max_height),
+        }
+    }
+
+    #[inline]
+    fn aspect_ratio(&self) -> Option<f32> {
+        convert::aspect_ratio(self.0.get_position().aspect_ratio)
+    }
+
+    #[inline]
+    fn margin(&self) -> taffy::Rect<taffy::LengthPercentageAuto> {
+        let margin_styles = self.0.get_margin();
+        taffy::Rect {
+            left: convert::margin(&margin_styles.margin_left),
+            right: convert::margin(&margin_styles.margin_right),
+            top: convert::margin(&margin_styles.margin_top),
+            bottom: convert::margin(&margin_styles.margin_bottom),
+        }
+    }
+
+    #[inline]
+    fn padding(&self) -> taffy::Rect<taffy::LengthPercentage> {
+        let padding_styles = self.0.get_padding();
+        taffy::Rect {
+            left: convert::length_percentage(&padding_styles.padding_left.0),
+            right: convert::length_percentage(&padding_styles.padding_right.0),
+            top: convert::length_percentage(&padding_styles.padding_top.0),
+            bottom: convert::length_percentage(&padding_styles.padding_bottom.0),
+        }
+    }
+
+    #[inline]
+    fn border(&self) -> taffy::Rect<taffy::LengthPercentage> {
+        let border_styles = self.0.get_border();
+        taffy::Rect {
+            left: taffy::LengthPercentage::Length(border_styles.border_left_width.to_f32_px()),
+            right: taffy::LengthPercentage::Length(border_styles.border_right_width.to_f32_px()),
+            top: taffy::LengthPercentage::Length(border_styles.border_top_width.to_f32_px()),
+            bottom: taffy::LengthPercentage::Length(border_styles.border_bottom_width.to_f32_px()),
+        }
+    }
+}
+
+// BlockContainerStyle impl
+#[cfg(feature = "block")]
+impl<T: Deref<Target = ComputedValues>> taffy::BlockContainerStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn text_align(&self) -> taffy::TextAlign {
+        convert::text_align(self.0.clone_text_align())
+    }
+}
+
+// BlockItemStyle impl
+#[cfg(feature = "block")]
+impl<T: Deref<Target = ComputedValues>> taffy::BlockItemStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn is_table(&self) -> bool {
+        convert::is_table(self.0.clone_display())
+    }
+}
+
+// FlexboxContainerStyle impl
+#[cfg(feature = "flexbox")]
+impl<T: Deref<Target = ComputedValues>> taffy::FlexboxContainerStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn flex_direction(&self) -> taffy::FlexDirection {
+        convert::flex_direction(self.0.get_position().flex_direction)
+    }
+
+    #[inline]
+    fn flex_wrap(&self) -> taffy::FlexWrap {
+        convert::flex_wrap(self.0.get_position().flex_wrap)
+    }
+
+    #[inline]
+    fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
+        let position_styles = self.0.get_position();
+        taffy::Size {
+            width: convert::gap(&position_styles.column_gap),
+            height: convert::gap(&position_styles.row_gap),
+        }
+    }
+
+    #[inline]
+    fn align_content(&self) -> Option<taffy::AlignContent> {
+        convert::content_alignment(self.0.get_position().align_content.0)
+    }
+
+    #[inline]
+    fn align_items(&self) -> Option<taffy::AlignItems> {
+        convert::item_alignment(self.0.get_position().align_items.0)
+    }
+
+    #[inline]
+    fn justify_content(&self) -> Option<taffy::JustifyContent> {
+        convert::content_alignment(self.0.get_position().justify_content.0)
+    }
+}
+
+// FlexboxItemStyle impl
+#[cfg(feature = "flexbox")]
+impl<T: Deref<Target = ComputedValues>> taffy::FlexboxItemStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn flex_basis(&self) -> taffy::Dimension {
+        convert::flex_basis(&self.0.get_position().flex_basis)
+    }
+
+    #[inline]
+    fn flex_grow(&self) -> f32 {
+        self.0.get_position().flex_grow.0
+    }
+
+    #[inline]
+    fn flex_shrink(&self) -> f32 {
+        self.0.get_position().flex_shrink.0
+    }
+
+    #[inline]
+    fn align_self(&self) -> Option<taffy::AlignSelf> {
+        convert::item_alignment(self.0.get_position().align_self.0 .0)
+    }
+}
+
+// GridContainerStyle impl
+#[cfg(feature = "grid")]
+impl<T: Deref<Target = ComputedValues>> taffy::GridContainerStyle for TaffyStyloStyle<T> {
+    type TemplateTrackList<'a>
+        = Vec<taffy::TrackSizingFunction>
+    where
+        Self: 'a;
+    type AutoTrackList<'a>
+        = Vec<taffy::NonRepeatedTrackSizingFunction>
+    where
+        Self: 'a;
+
+    #[inline]
+    fn grid_template_rows(&self) -> Self::TemplateTrackList<'_> {
+        convert::grid_template_tracks(&self.0.get_position().grid_template_rows)
+    }
+
+    #[inline]
+    fn grid_template_columns(&self) -> Self::TemplateTrackList<'_> {
+        convert::grid_template_tracks(&self.0.get_position().grid_template_columns)
+    }
+
+    #[inline]
+    fn grid_auto_rows(&self) -> Self::AutoTrackList<'_> {
+        convert::grid_auto_tracks(&self.0.get_position().grid_auto_rows)
+    }
+
+    #[inline]
+    fn grid_auto_columns(&self) -> Self::AutoTrackList<'_> {
+        convert::grid_auto_tracks(&self.0.get_position().grid_auto_columns)
+    }
+
+    #[inline]
+    fn grid_auto_flow(&self) -> taffy::GridAutoFlow {
+        convert::grid_auto_flow(self.0.get_position().grid_auto_flow)
+    }
+
+    #[inline]
+    fn gap(&self) -> taffy::Size<taffy::LengthPercentage> {
+        let position_styles = self.0.get_position();
+        taffy::Size {
+            width: convert::gap(&position_styles.column_gap),
+            height: convert::gap(&position_styles.row_gap),
+        }
+    }
+
+    #[inline]
+    fn align_content(&self) -> Option<taffy::AlignContent> {
+        convert::content_alignment(self.0.get_position().align_content.0)
+    }
+
+    #[inline]
+    fn justify_content(&self) -> Option<taffy::JustifyContent> {
+        convert::content_alignment(self.0.get_position().justify_content.0)
+    }
+
+    #[inline]
+    fn align_items(&self) -> Option<taffy::AlignItems> {
+        convert::item_alignment(self.0.get_position().align_items.0)
+    }
+
+    #[inline]
+    fn justify_items(&self) -> Option<taffy::AlignItems> {
+        convert::item_alignment(self.0.get_position().justify_items.computed.0)
+    }
+}
+
+// GridItemStyle impl
+#[cfg(feature = "grid")]
+impl<T: Deref<Target = ComputedValues>> taffy::GridItemStyle for TaffyStyloStyle<T> {
+    #[inline]
+    fn grid_row(&self) -> taffy::Line<taffy::GridPlacement> {
+        let position_styles = self.0.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_row_start),
+            end: convert::grid_line(&position_styles.grid_row_end),
+        }
+    }
+
+    #[inline]
+    fn grid_column(&self) -> taffy::Line<taffy::GridPlacement> {
+        let position_styles = self.0.get_position();
+        taffy::Line {
+            start: convert::grid_line(&position_styles.grid_column_start),
+            end: convert::grid_line(&position_styles.grid_column_end),
+        }
+    }
+
+    #[inline]
+    fn align_self(&self) -> Option<taffy::AlignSelf> {
+        convert::item_alignment(self.0.get_position().align_self.0 .0)
+    }
+
+    #[inline]
+    fn justify_self(&self) -> Option<taffy::AlignSelf> {
+        convert::item_alignment(self.0.get_position().justify_self.0 .0)
+    }
+}


### PR DESCRIPTION
This PR contains a new crate `stylo_taffy` which contains:

- Type conversions between `stylo` types and `taffy` types
- A function to convert  a `stylo::ComputeValues` into a `taffy::Style`
- A wrapper type `TaffyStyloStyle<T>` that wraps any `T: Deref<Target = ComputedValue>` and which implements Taffy's style traits, which allows it to be passed to Taffy's algorithms directly instead of Taffy's `Style` struct.

I believe this repository is the best place for this code to live as:

- It allows Servo, Blitz, and anybody else who wants to combine Stylo with Taffy to share this code
- It avoids any complications with having MIT/APACHE2.0 licensed code in the main Servo repo
- It means that any required fixups can happen directly as part of a Stylo sync, and there is not the additional step of having to update code in the Taffy repo first.

I can submit this upstream if there is agreement that this is the best place for this code.