### PR TITLE
Remove Servo-specific code from `malloc_size_of`

### DIFF
--- a/dom/Cargo.toml
+++ b/dom/Cargo.toml
@@ -11,3 +11,4 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "2"
+malloc_size_of = { path = "../malloc_size_of" }

--- a/dom/lib.rs
+++ b/dom/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use bitflags::bitflags;
+use malloc_size_of::malloc_size_of_is_0;
 
 // DOM types to be shared between Rust and C++.
 bitflags! {
@@ -159,3 +160,5 @@ bitflags! {
         const ALL_LOCALEDIR_BITS = Self::LTR_LOCALE.bits() | Self::RTL_LOCALE.bits();
     }
 }
+
+malloc_size_of_is_0!(ElementState, DocumentState);

--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -10,45 +10,17 @@ publish = false
 path = "lib.rs"
 
 [features]
-servo = [
-    "accountable-refcell",
-    "content-security-policy",
-    "crossbeam-channel",
-    "http",
-    "indexmap",
-    "keyboard-types",
-    "serde",
-    "serde_bytes",
-    "string_cache",
-    "url",
-    "uuid",
-    "webrender_api",
-    "xml5ever",
-]
 gecko = ["thin-vec/gecko-ffi"]
+servo = ["string_cache"]
 
 [dependencies]
-accountable-refcell = { version = "0.2.0", optional = true }
 app_units = "0.7"
-content-security-policy = { version = "0.5", features = ["serde"], optional = true }
-crossbeam-channel = { version = "0.5", optional = true }
 cssparser = "0.34"
-dom = { path = "../dom" }
 euclid = "0.22"
-http = { version = "0.2", optional = true }
-indexmap = { version = "2.2", optional = true }
-keyboard-types = { version = "0.7", optional = true }
 selectors = { path = "../selectors" }
-serde = { version = "1.0.195", optional = true }
-serde_bytes = { version = "0.11", optional = true }
 servo_arc = { path = "../servo_arc" }
 smallbitvec = "2.3.0"
 smallvec = "1.13"
 string_cache = { version = "0.8", optional = true }
 thin-vec = { version = "0.2.13" }
-tokio = { version = "1", features = ["sync"] }
-url = { version = "2.5", features = ["serde"], optional = true }
-uuid = { version = "1.7.0", optional = true }
 void = "1.0.2"
-webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65", optional = true }
-xml5ever = { version = "0.20", optional = true }

--- a/malloc_size_of/lib.rs
+++ b/malloc_size_of/lib.rs
@@ -46,50 +46,20 @@
 //!   Note: WebRender has a reduced fork of this crate, so that we can avoid
 //!   publishing this crate on crates.io.
 
-#[cfg(feature = "servo")]
-extern crate accountable_refcell;
 extern crate app_units;
-#[cfg(feature = "servo")]
-extern crate content_security_policy;
-#[cfg(feature = "servo")]
-extern crate crossbeam_channel;
 extern crate cssparser;
 extern crate euclid;
-#[cfg(feature = "servo")]
-extern crate http;
-#[cfg(feature = "servo")]
-extern crate keyboard_types;
 extern crate selectors;
-#[cfg(feature = "servo")]
-extern crate serde;
-#[cfg(feature = "servo")]
-extern crate serde_bytes;
 extern crate servo_arc;
 extern crate smallbitvec;
 extern crate smallvec;
-#[cfg(feature = "servo")]
-extern crate string_cache;
-#[cfg(feature = "url")]
-extern crate url;
-#[cfg(feature = "servo")]
-extern crate uuid;
 extern crate void;
-#[cfg(feature = "webrender_api")]
-extern crate webrender_api;
-#[cfg(feature = "servo")]
-extern crate xml5ever;
 
-#[cfg(feature = "servo")]
-use content_security_policy as csp;
-#[cfg(feature = "servo")]
-use serde_bytes::ByteBuf;
 use std::hash::{BuildHasher, Hash};
 use std::mem::size_of;
 use std::ops::Range;
 use std::ops::{Deref, DerefMut};
 use std::os::raw::c_void;
-#[cfg(feature = "servo")]
-use uuid::Uuid;
 use void::Void;
 
 /// A C function that takes a pointer to a heap allocation and returns its size.
@@ -331,24 +301,6 @@ where
 impl<T: MallocSizeOf> MallocSizeOf for [T] {
     fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
         let mut n = 0;
-        for elem in self.iter() {
-            n += elem.size_of(ops);
-        }
-        n
-    }
-}
-
-#[cfg(feature = "servo")]
-impl MallocShallowSizeOf for ByteBuf {
-    fn shallow_size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        unsafe { ops.malloc_size_of(self.as_ptr()) }
-    }
-}
-
-#[cfg(feature = "servo")]
-impl MallocSizeOf for ByteBuf {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        let mut n = self.shallow_size_of(ops);
         for elem in self.iter() {
             n += elem.size_of(ops);
         }
@@ -863,114 +815,7 @@ malloc_size_of_is_0!(app_units::Au);
 
 malloc_size_of_is_0!(cssparser::TokenSerializationType, cssparser::SourceLocation, cssparser::SourcePosition);
 
-malloc_size_of_is_0!(dom::ElementState, dom::DocumentState);
-
 malloc_size_of_is_0!(selectors::OpaqueElement);
-
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(csp::Destination);
-
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(Uuid);
-
-#[cfg(feature = "url")]
-impl MallocSizeOf for url::Host {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        match *self {
-            url::Host::Domain(ref s) => s.size_of(ops),
-            _ => 0,
-        }
-    }
-}
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BorderRadius);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BorderStyle);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::BoxShadowClipMode);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ColorF);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ComplexClipRegion);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ExtendMode);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::FilterOp);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ExternalScrollId);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::FontInstanceKey);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::GradientStop);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::GlyphInstance);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::NinePatchBorder);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ImageKey);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::ImageRendering);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::LineStyle);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::MixBlendMode);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::NormalBorder);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::RepeatMode);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::StickyOffsetBounds);
-#[cfg(feature = "webrender_api")]
-malloc_size_of_is_0!(webrender_api::TransformStyle);
-
-#[cfg(feature = "servo")]
-impl MallocSizeOf for keyboard_types::Key {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        match self {
-            keyboard_types::Key::Character(ref s) => s.size_of(ops),
-            _ => 0,
-        }
-    }
-}
-
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(keyboard_types::Modifiers);
-
-#[cfg(feature = "servo")]
-impl MallocSizeOf for xml5ever::QualName {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        self.prefix.size_of(ops) + self.ns.size_of(ops) + self.local.size_of(ops)
-    }
-}
-
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(std::time::Duration);
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(std::time::SystemTime);
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(std::time::Instant);
-#[cfg(feature = "servo")]
-malloc_size_of_hash_set!(indexmap::IndexSet<T, S>);
-#[cfg(feature = "servo")]
-malloc_size_of_hash_map!(indexmap::IndexMap<K, V, S>);
-#[cfg(feature = "servo")]
-malloc_size_of_is_0!(http::StatusCode);
-
-// Placeholder for unique case where internals of Sender cannot be measured.
-// malloc size of is 0 macro complains about type supplied!
-#[cfg(feature = "servo")]
-impl<T> MallocSizeOf for crossbeam_channel::Sender<T> {
-    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
-        0
-    }
-}
-
-#[cfg(feature = "servo")]
-impl<T> MallocSizeOf for tokio::sync::mpsc::UnboundedSender<T> {
-    fn size_of(&self, _ops: &mut MallocSizeOfOps) -> usize {
-        0
-    }
-}
 
 /// Measurable that defers to inner value and used to verify MallocSizeOf implementation in a
 /// struct.
@@ -988,12 +833,5 @@ impl<T: MallocSizeOf> Deref for Measurable<T> {
 impl<T: MallocSizeOf> DerefMut for Measurable<T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.0
-    }
-}
-
-#[cfg(feature = "servo")]
-impl<T: MallocSizeOf> MallocSizeOf for accountable_refcell::RefCell<T> {
-    fn size_of(&self, ops: &mut MallocSizeOfOps) -> usize {
-        self.borrow().size_of(ops)
     }
 }

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -100,7 +100,7 @@ thin-vec = "0.2.1"
 uluru = "3.0"
 unicode-bidi = { version = "0.3", default-features = false }
 void = "1.0.2"
-url = { version = "2.5", optional = true }
+url = { version = "2.5", optional = true, features = ["serde"] }
 
 [build-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
Servo will use a forked version of `malloc_size_of` so that it does not
push depenencies down into Stylo.

Corresponding upstream change: https://phabricator.services.mozilla.com/D229764

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
