### PR TITLE
Remove dependency on `webrender_api`

### DIFF
--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -11,7 +11,7 @@ name = "style_traits"
 path = "lib.rs"
 
 [features]
-servo = ["servo_atoms", "cssparser/serde", "webrender_api", "url", "euclid/serde"]
+servo = ["servo_atoms", "cssparser/serde", "url", "euclid/serde"]
 gecko = []
 
 [dependencies]
@@ -30,4 +30,3 @@ thin-vec = "0.2"
 to_shmem = { path = "../to_shmem" }
 to_shmem_derive = { path = "../to_shmem_derive" }
 url = { version = "2.5", optional = true }
-webrender_api = { git = "https://github.com/servo/webrender", branch = "0.65", optional = true }

--- a/style_traits/lib.rs
+++ b/style_traits/lib.rs
@@ -33,11 +33,7 @@ extern crate to_shmem;
 #[macro_use]
 extern crate to_shmem_derive;
 #[cfg(feature = "servo")]
-extern crate webrender_api;
-#[cfg(feature = "servo")]
 extern crate url;
-#[cfg(feature = "servo")]
-pub use webrender_api::units::DevicePixel;
 
 use cssparser::{CowRcStr, Token};
 use selectors::parser::SelectorParseErrorKind;
@@ -47,12 +43,10 @@ use servo_atoms::Atom;
 /// One hardware pixel.
 ///
 /// This unit corresponds to the smallest addressable element of the display hardware.
-#[cfg(not(feature = "servo"))]
 #[derive(Clone, Copy, Debug)]
 pub enum DevicePixel {}
 
 /// Represents a mobile style pinch zoom factor.
-/// TODO(gw): Once WR supports pinch zoom, use a type directly from webrender_api.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "servo", derive(Deserialize, Serialize, MallocSizeOf))]
 pub struct PinchZoomFactor(f32);


### PR DESCRIPTION
I have submitted this upstream: https://bugzilla.mozilla.org/show_bug.cgi?id=1933010

We can actually land the Servo PR without landing this first. But we might want to land anyway this to ensure that Servo doesn't regress before the next stylo sync.

Servo PR: https://github.com/servo/servo/pull/34353