### PR TITLE
Eliminate thread pool mutex

### DIFF
--- a/style/global_style_data.rs
+++ b/style/global_style_data.rs
@@ -101,7 +101,7 @@ impl StyleThreadPool {
         }
         {
             // Drop the pool.
-            let _ = STYLE_THREAD_POOL.lock().unwrap().style_thread_pool.write().take();
+            let _ = STYLE_THREAD_POOL.style_thread_pool.write().take();
         }
 
         // Join spawned threads until all of the threads have been joined. This
@@ -153,7 +153,7 @@ pub(crate) const STYLO_MAX_THREADS: usize = 6;
 
 lazy_static! {
     /// Global thread pool
-    pub static ref STYLE_THREAD_POOL: std::sync::Mutex<StyleThreadPool> = {
+    pub static ref STYLE_THREAD_POOL: StyleThreadPool = {
         use std::cmp;
         // We always set this pref on startup, before layout or script have had a chance of
         // accessing (and thus creating) the thread-pool.
@@ -196,10 +196,10 @@ lazy_static! {
             (workers.ok(), Some(num_threads))
         };
 
-        std::sync::Mutex::new(StyleThreadPool {
+        StyleThreadPool {
             num_threads,
             style_thread_pool: RwLock::new(pool),
-        })
+        }
     };
 
     /// Global style data


### PR DESCRIPTION
This was quite straightforward (just remove the Mutex and the calls to the lock methods). And `StyleThreadPool` already internally contains an `RwLock`. Perhaps this was previously required but isn't anymore?

Reduces the diff with upstream which doesn't have this Mutex.

Servo PR:
- https://github.com/servo/servo/pull/34480