### PR TITLE
Add getter for prefers color scheme value found on Device

### DIFF
--- a/style/servo/media_queries.rs
+++ b/style/servo/media_queries.rs
@@ -301,6 +301,11 @@ impl Device {
         AbsoluteColor::BLACK
     }
 
+    /// Returns color scheme of the current device
+    pub fn color_scheme(&self) -> PrefersColorScheme {
+        self.prefers_color_scheme
+    }
+
     pub(crate) fn is_dark_color_scheme(&self, _: ColorSchemeFlags) -> bool {
         false
     }

--- a/style/servo/media_queries.rs
+++ b/style/servo/media_queries.rs
@@ -301,7 +301,7 @@ impl Device {
         AbsoluteColor::BLACK
     }
 
-    /// Returns color scheme of the current device
+    /// Returns the color scheme of this [`Device`].
     pub fn color_scheme(&self) -> PrefersColorScheme {
         self.prefers_color_scheme
     }


### PR DESCRIPTION
Add function to get prefers color scheme value associated with the `Device`. This helps with completing the implementation to update the color scheme from the platform theme change event, [found here](https://github.com/servo/servo/pull/34532).

Do I have to sign commits on stylo as well?

@nicoburns 