### PR TITLE
Use truncation instead of rounding to resolve percentages into app units

### DIFF
--- a/style/values/computed/length_percentage.rs
+++ b/style/values/computed/length_percentage.rs
@@ -518,7 +518,11 @@ impl LengthPercentage {
     /// Returns the used value.
     #[inline]
     pub fn to_used_value(&self, containing_length: Au) -> Au {
-        Au::from(self.to_pixel_length(containing_length))
+        let length = self.to_pixel_length(containing_length);
+        if let Unpacked::Percentage(_) = self.unpack() {
+            return Au::from_f32_px_trunc(length.px());
+        }
+        Au::from(length)
     }
 
     /// Returns the used value as CSSPixelLength.
@@ -531,7 +535,11 @@ impl LengthPercentage {
     #[inline]
     pub fn maybe_to_used_value(&self, container_len: Option<Au>) -> Option<Au> {
         self.maybe_percentage_relative_to(container_len.map(Length::from))
-            .map(Au::from)
+            .map(if let Unpacked::Percentage(_) = self.unpack() {
+                |length: Length| Au::from_f32_px_trunc(length.px())
+            } else {
+                Au::from
+            })
     }
 
     /// If there are special rules for computing percentages in a value (e.g.


### PR DESCRIPTION
change conversion to appunit from float of percentage calcuation, prevent child box size is calculated too large.

Servo PR: https://github.com/servo/servo/pull/34714