### PR TITLE
Implement `::backdrop` pseudo-element parsing

### DIFF
--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -50,6 +50,8 @@ pub enum PseudoElement {
     // them.  Also, make sure the UA sheet has the !important rules some of the
     // APPLIES_TO_PLACEHOLDER properties expect!
 
+    Backdrop,
+
     // Non-eager pseudos.
     DetailsSummary,
     DetailsContent,
@@ -82,6 +84,7 @@ impl ToCss for PseudoElement {
             After => "::after",
             Before => "::before",
             Selection => "::selection",
+            Backdrop => "::backdrop",
             DetailsSummary => "::-servo-details-summary",
             DetailsContent => "::-servo-details-content",
             ServoAnonymousBox => "::-servo-anonymous-box",
@@ -232,7 +235,7 @@ impl PseudoElement {
             PseudoElement::After | PseudoElement::Before | PseudoElement::Selection => {
                 PseudoElementCascadeType::Eager
             },
-            PseudoElement::DetailsSummary => PseudoElementCascadeType::Lazy,
+            PseudoElement::Backdrop | PseudoElement::DetailsSummary => PseudoElementCascadeType::Lazy,
             PseudoElement::DetailsContent |
             PseudoElement::ServoAnonymousBox |
             PseudoElement::ServoAnonymousTable |
@@ -594,6 +597,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
             "before" => Before,
             "after" => After,
             "selection" => Selection,
+            "backdrop" => Backdrop,
             "-servo-details-summary" => {
                 if !self.in_user_agent_stylesheet() {
                     return Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))


### PR DESCRIPTION
## Context

- Fixes https://github.com/servo/servo/issues/34820

## Notes

Github.com sets it's root-level CSS variables using a selector that includes a `::backdrop` pseudo selector. It's not quite this, but it's morally equivalent to `html, html ::backdrop`. And the presence of `::backdrop` causes the entire selector to fail to parse meaning that the variables never apply and styling is way off.

Changing the selector to `html, html ::non-existent-selector` causes the styles to fail to apply in Chrome too. So I think the strict parsing is correct per the spec. So I believe the only way to make this work is to implement parsing for `::backdrop`. I don't think we support creating a backdrop in a current Servo, but if we did support then we probably would support matching styles against it, so enabling the selector seems reasonable to me.

## Feedback wanted

I wasn't sure if it should be a `Lazy` pseudo-element. But `Lazy` is documented as being for regular but rarely used pseudo-elements which seemed to fit, whereas `PreComputed` is documented as being only for internal pseudo-elements which didn't seem to fit.