### PR TITLE
API tweaks for Taffy `calc()` integration

### DIFF
--- a/selectors/tree.rs
+++ b/selectors/tree.rs
@@ -31,6 +31,11 @@ impl OpaqueElement {
         }
     }
 
+    /// Creates a new OpaqueElement from a type-erased non-null pointer
+    pub fn from_non_null_ptr(ptr: NonNull<()>) -> Self {
+        Self(ptr)
+    }
+
     /// Returns a const ptr to the contained reference.
     pub unsafe fn as_const_ptr<T>(&self) -> *const T {
         self.0.as_ptr() as *const T

--- a/style/values/computed/length_percentage.rs
+++ b/style/values/computed/length_percentage.rs
@@ -202,9 +202,12 @@ impl ToResolvedValue for LengthPercentage {
 
 /// An unpacked `<length-percentage>` that borrows the `calc()` variant.
 #[derive(Clone, Debug, PartialEq, ToCss)]
-enum Unpacked<'a> {
+pub enum Unpacked<'a> {
+    /// A `calc()` value
     Calc(&'a CalcLengthPercentage),
+    /// A length value
     Length(Length),
+    /// A percentage value
     Percentage(Percentage),
 }
 
@@ -397,8 +400,10 @@ impl LengthPercentage {
         }
     }
 
+    /// Unpack the tagged pointer representation of a length-percentage into an enum
+    /// representation with separate tag and value.
     #[inline]
-    fn unpack<'a>(&'a self) -> Unpacked<'a> {
+    pub fn unpack<'a>(&'a self) -> Unpacked<'a> {
         unsafe {
             match self.tag() {
                 Tag::Calc => Unpacked::Calc(&*self.calc_ptr()),


### PR DESCRIPTION
Submitted upstream as https://bugzilla.mozilla.org/show_bug.cgi?id=1939791, but don't want to wait for sync before posting Servo PR.

Changes made:

- Make `LengthPercentage::unpack` and the `Unpack` type it returns public. Used to access the address of the boxed `CalcLengthPercentage` value so that it can be passed into Taffy.
- Add `OpaqueElement::from_non_null_ptr`. This is used to avoid Undefined Behaviour when constructing an `OpaqueElement` from an index which is unlikely to be a valid memory address. Technically not related to `calc()` but it's a small change, and I've bundled them when submitting upstream.

This will help enable support for `calc()` values for CSS Grid containers/items in Servo.