### PR TITLE
Enable relative color syntax

### DIFF
--- a/style_static_prefs/src/lib.rs
+++ b/style_static_prefs/src/lib.rs
@@ -24,6 +24,9 @@ macro_rules! pref {
     ("layout.css.basic-shape-xywh.enabled") => {
         true
     };
+    ("layout.css.relative-color-syntax.enabled") => {
+        true
+    };
     ("layout.css.stretch-size-keyword.enabled") => {
         true
     };


### PR DESCRIPTION
Firefox has it enabled by default since version 128.