### PR TITLE
Enable overflow:clip for Servo

### DIFF
--- a/style/properties/data.py
+++ b/style/properties/data.py
@@ -587,6 +587,7 @@ class Longhand(Property):
                 "Overflow",
                 "OverflowAnchor",
                 "OverflowClipBox",
+                "OverflowClipMargin",
                 "OverflowWrap",
                 "OverscrollBehavior",
                 "PageOrientation",

--- a/style/properties/longhands/margin.mako.rs
+++ b/style/properties/longhands/margin.mako.rs
@@ -30,12 +30,12 @@
 
 ${helpers.predefined_type(
     "overflow-clip-margin",
-    "Length",
-    "computed::Length::zero()",
-    parse_method="parse_non_negative",
-    engines="gecko",
+    "OverflowClipMargin",
+    "generics::box_::OverflowClipMargin::None",
+    engines="gecko servo",
     spec="https://drafts.csswg.org/css-overflow/#propdef-overflow-clip-margin",
     affects="overflow",
+    animation_type="discrete",
 )}
 
 % for index, side in enumerate(ALL_SIDES):

--- a/style/values/computed/box.rs
+++ b/style/values/computed/box.rs
@@ -18,7 +18,7 @@ use style_traits::{CssWriter, ToCss};
 pub use crate::values::specified::box_::{
     Appearance, BaselineSource, BreakBetween, BreakWithin, Clear, Contain,
     ContainerName, ContainerType, ContentVisibility, Display, Float, Overflow,
-    OverflowAnchor, OverflowClipBox, OverscrollBehavior, ScrollSnapAlign, ScrollSnapAxis,
+    OverflowAnchor, OverflowClipBox, OverflowClipMargin, OverscrollBehavior, ScrollSnapAlign, ScrollSnapAxis,
     ScrollSnapStop, ScrollSnapStrictness, ScrollSnapType, ScrollbarGutter, TouchAction, WillChange,
 };
 

--- a/style/values/computed/mod.rs
+++ b/style/values/computed/mod.rs
@@ -53,7 +53,7 @@ pub use self::border::{
 pub use self::box_::{
     Appearance, BaselineSource, BreakBetween, BreakWithin, Clear, Contain, ContainIntrinsicSize,
     ContainerName, ContainerType, ContentVisibility, Display, Float, LineClamp, Overflow,
-    OverflowAnchor, OverflowClipBox, OverscrollBehavior, Perspective, Resize, ScrollSnapAlign,
+    OverflowAnchor, OverflowClipBox, OverflowClipMargin, OverscrollBehavior, Perspective, Resize, ScrollSnapAlign,
     ScrollSnapAxis, ScrollSnapStop, ScrollSnapStrictness, ScrollSnapType, ScrollbarGutter,
     TouchAction, VerticalAlign, WillChange, Zoom,
 };

--- a/style/values/generics/box.rs
+++ b/style/values/generics/box.rs
@@ -211,3 +211,32 @@ impl<L> Perspective<L> {
         Perspective::None
     }
 }
+
+#[derive(
+    Animate,
+    Clone,
+    Copy,
+    Debug,
+    MallocSizeOf,
+    PartialEq,
+    SpecifiedValueInfo,
+    ToAnimatedValue,
+    ToAnimatedZero,
+    ToComputedValue,
+    ToCss,
+    ToResolvedValue,
+    ToShmem,
+)]
+/// A generic value for the `overflow-clip-margin` property.
+pub enum GenericOverflowClipMargin<NonNegativeLength, VisualBox> {
+    /// None
+    None,
+    /// A non-negative length.
+    Margin(NonNegativeLength),
+    /// A visual box.
+    VisualBox(VisualBox),
+    /// Both a visual box and a non-negative length.
+    VisualBoxAndMargin(VisualBox, NonNegativeLength),
+}
+
+pub use self::GenericOverflowClipMargin as OverflowClipMargin;

--- a/style/values/specified/mod.rs
+++ b/style/values/specified/mod.rs
@@ -42,7 +42,7 @@ pub use self::border::{
 pub use self::box_::{
     Appearance, BaselineSource, BreakBetween, BreakWithin, Clear, Contain, ContainIntrinsicSize,
     ContainerName, ContainerType, ContentVisibility, Display, Float, LineClamp, Overflow,
-    OverflowAnchor, OverflowClipBox, OverscrollBehavior, Perspective, Resize, ScrollSnapAlign,
+    OverflowAnchor, OverflowClipBox, OverflowClipMargin, OverscrollBehavior, Perspective, Resize, ScrollSnapAlign,
     ScrollSnapAxis, ScrollSnapStop, ScrollSnapStrictness, ScrollSnapType, ScrollbarGutter,
     TouchAction, VerticalAlign, WillChange, Zoom,
 };


### PR DESCRIPTION
This PR help `overflow : clip` implementation in Servo
- Enable `overflow : clip` for Servo
- Implement `overflow-clip-margin`

Test case:
- /css/css-overflow/parsing/overflow-clip-margin.html
- /css/css-overflow/parsing/overflow-clip-margin-computed.html

Servo PR: https://github.com/servo/servo/pull/35103

cc: @xiaochengh