### PR TITLE
Enable overflow: clip and overflow-clip-margin for Servo

### DIFF
--- a/style/properties/longhands/margin.mako.rs
+++ b/style/properties/longhands/margin.mako.rs
@@ -33,7 +33,7 @@ ${helpers.predefined_type(
     "Length",
     "computed::Length::zero()",
     parse_method="parse_non_negative",
-    engines="gecko",
+    engines="gecko servo",
     spec="https://drafts.csswg.org/css-overflow/#propdef-overflow-clip-margin",
     affects="overflow",
 )}

--- a/style/values/specified/box.rs
+++ b/style/values/specified/box.rs
@@ -1813,7 +1813,6 @@ pub enum Overflow {
     Hidden,
     Scroll,
     Auto,
-    #[cfg(feature = "gecko")]
     Clip,
 }
 
@@ -1829,7 +1828,6 @@ impl Parse for Overflow {
             "hidden" => Self::Hidden,
             "scroll" => Self::Scroll,
             "auto" | "overlay" => Self::Auto,
-            #[cfg(feature = "gecko")]
             "clip" => Self::Clip,
             #[cfg(feature = "gecko")]
             "-moz-hidden-unscrollable" if static_prefs::pref!("layout.css.overflow-moz-hidden-unscrollable.enabled") => {
@@ -1852,7 +1850,6 @@ impl Overflow {
         match *self {
             Self::Hidden | Self::Scroll | Self::Auto => *self,
             Self::Visible => Self::Auto,
-            #[cfg(feature = "gecko")]
             Self::Clip => Self::Hidden,
         }
     }


### PR DESCRIPTION
Enable `overflow: clip` for Servo
Enable `overflow-clip-margin` for Servo

Servo PR: https://github.com/servo/servo/pull/35103

cc: @xiaochengh