### PR TITLE
Let `resolve_color()` take its parameter by reference

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1874,9 +1874,9 @@ impl ComputedValues {
     ///
     /// Usage example:
     /// let top_color =
-    ///   style.resolve_color(style.get_border().clone_border_top_color());
+    ///   style.resolve_color(&style.get_border().clone_border_top_color());
     #[inline]
-    pub fn resolve_color(&self, color: computed::Color) -> crate::color::AbsoluteColor {
+    pub fn resolve_color(&self, color: &computed::Color) -> crate::color::AbsoluteColor {
         let current_color = self.get_inherited_text().clone_color();
         color.resolve_to_absolute(&current_color)
     }

--- a/style/values/resolved/color.rs
+++ b/style/values/resolved/color.rs
@@ -16,7 +16,7 @@ impl ToResolvedValue for computed::Color {
 
     #[inline]
     fn to_resolved_value(self, context: &Context) -> Self::ResolvedValue {
-        context.style.resolve_color(self)
+        context.style.resolve_color(&self)
     }
 
     #[inline]


### PR DESCRIPTION
This way the callers don't have to clone it if they don't have ownership or want to use the value later.

Servo PR: https://github.com/servo/servo/pull/35247