### PR TITLE
Parse `::slotted` selector

### DIFF
--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -712,6 +712,10 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
     fn parse_host(&self) -> bool {
         true
     }
+
+    fn parse_slotted(&self) -> bool {
+        true
+    }
 }
 
 impl SelectorImpl {


### PR DESCRIPTION
Servo already supports this selector, it just needs to be enabled.