### PR TITLE
[bugfix](stylo): Fix "bare CR not allowed in doc-comment" windows

### DIFF
--- a/style/counter_style/update_predefined.py
+++ b/style/counter_style/update_predefined.py
@@ -16,7 +16,7 @@ def main(filename):
         if b'data-dfn-for="<counter-style-name>"' in line
         or b'data-dfn-for="<counter-style>"' in line
     ]
-    with open(filename, "w") as f:
+    with open(filename, "w", newline='', encoding="utf-8") as f:
         f.write(
             """\
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/style/properties/build.py
+++ b/style/properties/build.py
@@ -114,7 +114,7 @@ def write(directory, filename, content):
     if not os.path.exists(directory):
         os.makedirs(directory)
     full_path = os.path.join(directory, filename)
-    open(full_path, "w", encoding="utf-8").write(content)
+    open(full_path, "w", newline='', encoding="utf-8").write(content)
 
     python_addr = RE_PYTHON_ADDR.search(content)
     if python_addr:


### PR DESCRIPTION
In case of building servo on Windows platform; Specifically after the following PR: https://github.com/servo/stylo/pull/122
I keep getting following error message:  "bare CR not allowed in doc-comment".
Changes bellow helped me to resolve the problem