### PR TITLE
Reinstate missing gecko-specific import

### DIFF
--- a/style/properties/cascade.rs
+++ b/style/properties/cascade.rs
@@ -11,6 +11,8 @@ use crate::custom_properties::{
     CustomPropertiesBuilder, DeferFontRelativeCustomPropertyResolution,
 };
 use crate::dom::TElement;
+#[cfg(feature = "gecko")]
+use crate::font_metrics::FontMetricsOrientation;
 use crate::logical_geometry::WritingMode;
 use crate::properties::{
     property_counts, CSSWideKeyword, ComputedValues, DeclarationImportanceIterator, Importance,


### PR DESCRIPTION
I've been working through the diff with upstream. This import is gecko-specific code which is referenced by gecko-feature-flagged code in both our copy and upstream Stylo. As such, I think we ought to have it in our copy (it won't be compiled under the "servo" variant anyway).