### PR TITLE
Remove unnecessary imports

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1949,7 +1949,6 @@ impl ComputedValues {
 
     /// Get the initial computed values.
     pub fn initial_values_with_font_override(default_font: super::style_structs::Font) -> Arc<Self> {
-        use crate::logical_geometry::WritingMode;
         use crate::computed_value_flags::ComputedValueFlags;
         use servo_arc::Arc;
         use super::{ComputedValues, ComputedValuesInner, longhands, style_structs};

--- a/style/values/specified/box.rs
+++ b/style/values/specified/box.rs
@@ -15,7 +15,7 @@ use crate::values::specified::{AllowQuirks, Integer, NonNegativeNumberOrPercenta
 use crate::values::CustomIdent;
 use cssparser::Parser;
 use num_traits::FromPrimitive;
-use std::fmt::{self, Debug, Write};
+use std::fmt::{self, Write};
 use style_traits::{CssWriter, KeywordsCollectFn, ParseError};
 use style_traits::{SpecifiedValueInfo, StyleParseErrorKind, ToCss};
 

--- a/style/values/specified/length.rs
+++ b/style/values/specified/length.rs
@@ -1231,7 +1231,6 @@ impl NoCalcLength {
     /// absolute or (if a font metrics getter is provided) font-relative units.
     #[cfg(feature = "gecko")]
     #[inline]
-    #[cfg(feature = "gecko")]
     pub fn to_computed_pixel_length_with_font_metrics(
         &self,
         get_font_metrics: Option<impl Fn() -> GeckoFontMetrics>,


### PR DESCRIPTION
1. Import is unnecessary as the same type is imported at the top of the file.
2. In general, you don't need to import Debug derive macro

These imports do not exist upstream so this helps to reduce the diff.