### PR TITLE
fix: add atoms "show"

### DIFF
--- a/atoms/static_atoms.txt
+++ b/atoms/static_atoms.txt
@@ -141,6 +141,7 @@ selectionchange
 selectstart
 serif
 sessionavailable
+show
 signalingstatechange
 slotchange
 squeeze


### PR DESCRIPTION
Adding `show` static atoms for `Notification` `show` event.

ref: https://github.com/servo/servo/issues/34841
spec: https://notifications.spec.whatwg.org/#showing-a-notification step 8