### PR TITLE
Bump app_units dependency to 0.7.8

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -51,7 +51,7 @@ gecko_refcount_logging = []
 nsstring = []
 
 [dependencies]
-app_units = "0.7"
+app_units = "0.7.8"
 arrayvec = "0.7"
 atomic_refcell = "0.1"
 bitflags = "2"


### PR DESCRIPTION
The latest version of Stylo requires app_units `0.7.8`, so let's formalize that in the `Cargo.toml` (without this my build broke until I ran `cargo update` which I knew to do but other may not)