### PR TITLE
Sync upstream branch hourly rather than daily

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -2,7 +2,7 @@ name: Sync upstream with mozilla-central
 
 on:
   schedule:
-    - cron: '0 13 * * *'
+    - cron: '13 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Syncing isn't a taxing activity for either our CI (typically completes in ~3 mins) or Mozilla (just does the equivalent of a single git pull). And it's useful to have our `upstream` up-to-date with the latest commits as soon as they are available.

So this changes our config to sync hourly rather than daily