### PR TITLE
Use Arc for PaintWorklet arguments

### DIFF
--- a/style/values/generics/image.rs
+++ b/style/values/generics/image.rs
@@ -13,6 +13,7 @@ use crate::values::generics::Optional;
 use crate::values::serialize_atom_identifier;
 use crate::Atom;
 use crate::Zero;
+use servo_arc::Arc;
 use std::fmt::{self, Write};
 use style_traits::{CssWriter, ToCss};
 
@@ -367,9 +368,10 @@ pub struct PaintWorklet {
     pub name: Atom,
     /// The arguments for the worklet.
     /// TODO: store a parsed representation of the arguments.
+    #[cfg_attr(feature = "servo", ignore_malloc_size_of = "Arc")]
     #[compute(no_field_bound)]
     #[resolve(no_field_bound)]
-    pub arguments: Vec<custom_properties::SpecifiedValue>,
+    pub arguments: Vec<Arc<custom_properties::SpecifiedValue>>,
 }
 
 impl ::style_traits::SpecifiedValueInfo for PaintWorklet {}

--- a/style/values/specified/image.rs
+++ b/style/values/specified/image.rs
@@ -1275,12 +1275,14 @@ impl<T> generic::ColorStop<Color, T> {
 impl PaintWorklet {
     #[cfg(feature = "servo")]
     fn parse_args<'i>(context: &ParserContext, input: &mut Parser<'i, '_>) -> Result<Self, ParseError<'i>> {
+        use servo_arc::Arc;
+
         use crate::custom_properties::SpecifiedValue;
         let name = Atom::from(&**input.expect_ident()?);
         let arguments = input
             .try_parse(|input| {
                 input.expect_comma()?;
-                input.parse_comma_separated(|input| SpecifiedValue::parse(input, &context.url_data))
+                input.parse_comma_separated(|input| SpecifiedValue::parse(input, &context.url_data).map(Arc::new))
             })
             .unwrap_or_default();
         Ok(Self { name, arguments })


### PR DESCRIPTION
This is a performance optimization from Gecko (part of the diff) that I think we ought to adopt. Partly because I doubt Gecko will accept a reversion of this upstream.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1405411

No Servo changes required.