### PR TITLE
Make servo feature default

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -18,6 +18,7 @@ path = "lib.rs"
 doctest = false
 
 [features]
+default = ["servo"]
 gecko = [
     "bindgen",
     "malloc_size_of/gecko",


### PR DESCRIPTION
We probably won't be able to upstream this. But IMO it would be reasonable for us to keep this downstream. And it's a nice QoL improvement for users of the crate (and indeed for us when we want to build Stylo standalone).