### PR TITLE
Rename upstream crates to stylo*

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "malloc_size_of"
+name = "stylo_malloc_size_of"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "style"
+name = "stylo"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
@@ -70,7 +70,7 @@ itertools = "0.10"
 itoa = "1.0"
 lazy_static = "1"
 log = "0.4"
-malloc_size_of = { path = "../malloc_size_of" }
+malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"
 markup5ever = { version = "0.15", optional = true }
 matches = "0.1"
@@ -93,8 +93,8 @@ static_assertions = "1.1"
 static_prefs = { version = "0.1", path = "../stylo_static_prefs", package = "stylo_static_prefs" }
 string_cache = { version = "0.8", optional = true }
 style_config = { version = "0.1", path = "../stylo_config", package = "stylo_config", optional = true }
-style_derive = {path = "../style_derive"}
-style_traits = {path = "../style_traits"}
+style_derive = { path = "../style_derive", package = "stylo_derive" }
+style_traits = { path = "../style_traits", package = "stylo_traits" }
 to_shmem = {path = "../to_shmem"}
 to_shmem_derive = {path = "../to_shmem_derive"}
 thin-vec = "0.2.1"

--- a/style_derive/Cargo.toml
+++ b/style_derive/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "style_derive"
+name = "stylo_derive"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "style_traits"
+name = "stylo_traits"
 version = "0.0.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
@@ -20,7 +20,7 @@ app_units = "0.7"
 bitflags = "2"
 cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f" }
 euclid = "0.22"
-malloc_size_of = { path = "../malloc_size_of" }
+malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"
 selectors = { path = "../selectors" }
 serde = "1.0"

--- a/stylo_dom/Cargo.toml
+++ b/stylo_dom/Cargo.toml
@@ -14,4 +14,4 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "2"
-malloc_size_of = { path = "../malloc_size_of" }
+malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }


### PR DESCRIPTION
Follows on from https://github.com/servo/stylo/pull/131

I have also submitted this upstream (https://bugzilla.mozilla.org/show_bug.cgi?id=1938783) but they are still debating whether they wish to accept the change. We need it either way as it is strictly necessary for publishing to crates.io.