### PR TITLE
Prepare for `v0.2.0` release

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_malloc_size_of"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/stylo"
@@ -17,8 +17,8 @@ servo = ["string_cache"]
 app_units = "0.7"
 cssparser = "0.35"
 euclid = "0.22"
-selectors = { path = "../selectors" }
-servo_arc = { path = "../servo_arc" }
+selectors = { version = "0.27", path = "../selectors" }
+servo_arc = { version = "0.4", path = "../servo_arc" }
 smallbitvec = "2.3.0"
 smallvec = "1.13"
 string_cache = { version = "0.8", optional = true }

--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selectors"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/selectors/"
 description = "CSS Selectors matching for Rust"
@@ -29,7 +29,7 @@ phf = "0.11"
 precomputed-hash = "0.1"
 servo_arc = { version = "0.4", path = "../servo_arc" }
 smallvec = "1.0"
-to_shmem = { version = "0.1", path = "../to_shmem", features = ["servo_arc"], optional = true }
+to_shmem = { version = "0.2", path = "../to_shmem", features = ["servo_arc"], optional = true }
 to_shmem_derive = { version = "0.1", path = "../to_shmem_derive", optional = true }
 new_debug_unreachable = "1"
 

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
@@ -59,7 +59,7 @@ bitflags = "2"
 byteorder = "1.0"
 cssparser = "0.35"
 derive_more = { version = "0.99", default-features = false, features = ["add", "add_assign", "deref", "deref_mut", "from"] }
-dom = { path = "../stylo_dom", version = "0.1", package = "stylo_dom" }
+dom = { version = "0.2", path = "../stylo_dom", package = "stylo_dom" }
 new_debug_unreachable = "1.0"
 encoding_rs = {version = "0.8", optional = true}
 euclid = "0.22"
@@ -70,7 +70,7 @@ itertools = "0.10"
 itoa = "1.0"
 lazy_static = "1"
 log = "0.4"
-malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
+malloc_size_of = { version = "0.2", path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"
 markup5ever = { version = "0.15", optional = true }
 matches = "0.1"
@@ -90,13 +90,13 @@ stylo_atoms = {path = "../stylo_atoms", optional = true}
 smallbitvec = "2.3.0"
 smallvec = "1.0"
 static_assertions = "1.1"
-static_prefs = { version = "0.1", path = "../stylo_static_prefs", package = "stylo_static_prefs" }
+static_prefs = { version = "0.2", path = "../stylo_static_prefs", package = "stylo_static_prefs" }
 string_cache = { version = "0.8", optional = true }
-style_config = { version = "0.1", path = "../stylo_config", package = "stylo_config", optional = true }
-style_derive = { path = "../style_derive", package = "stylo_derive" }
-style_traits = { path = "../style_traits", package = "stylo_traits" }
-to_shmem = {path = "../to_shmem"}
-to_shmem_derive = {path = "../to_shmem_derive"}
+style_config = { version = "0.2", path = "../stylo_config", package = "stylo_config", optional = true }
+style_derive = { version = "0.2", path = "../style_derive", package = "stylo_derive" }
+style_traits = { version = "0.2", path = "../style_traits", package = "stylo_traits" }
+to_shmem = { version = "0.2", path = "../to_shmem" }
+to_shmem_derive = { version = "0.1", path = "../to_shmem_derive" }
 thin-vec = "0.2.1"
 uluru = "3.0"
 unicode-bidi = { version = "0.3", default-features = false }

--- a/style_derive/Cargo.toml
+++ b/style_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_derive"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_traits"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
@@ -20,13 +20,13 @@ app_units = "0.7"
 bitflags = "2"
 cssparser = "0.35"
 euclid = "0.22"
-malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
+malloc_size_of = { version = "0.2", path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"
-selectors = { path = "../selectors" }
+selectors = { version = "0.27", path = "../selectors" }
 serde = "1.0"
-servo_arc = { path = "../servo_arc" }
-stylo_atoms = { path = "../stylo_atoms", optional = true }
+servo_arc = { version = "0.4", path = "../servo_arc" }
+stylo_atoms = { version = "0.2", path = "../stylo_atoms", optional = true }
 thin-vec = "0.2"
-to_shmem = { path = "../to_shmem" }
-to_shmem_derive = { path = "../to_shmem_derive" }
+to_shmem = { version = "0.2", path = "../to_shmem" }
+to_shmem_derive = { version = "0.1", path = "../to_shmem_derive" }
 url = { version = "2.5", optional = true }

--- a/stylo_atoms/Cargo.toml
+++ b/stylo_atoms/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_atoms"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/stylo_atoms/"
 description = "Interned string type for the Servo and Stylo projects"

--- a/stylo_config/Cargo.toml
+++ b/stylo_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_config"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/stylo_config/"
 description = "Runtime configuration for Stylo"

--- a/stylo_dom/Cargo.toml
+++ b/stylo_dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_dom"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/stylo_dom/"
 description = "DOM state types for Stylo"
@@ -14,4 +14,4 @@ path = "lib.rs"
 
 [dependencies]
 bitflags = "2"
-malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
+malloc_size_of = { version = "0.2", path = "../malloc_size_of", package = "stylo_malloc_size_of" }

--- a/stylo_static_prefs/Cargo.toml
+++ b/stylo_static_prefs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo_static_prefs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 documentation = "https://docs.rs/stylo_static_prefs/"
 description = "Static configuration for Stylo"

--- a/to_shmem/Cargo.toml
+++ b/to_shmem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "to_shmem"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"


### PR DESCRIPTION
Prepare Stylo for a `v0.2.0` release. Closes #95.

### Dependencies

Before merging this and releasing we should:
- [x] Sync (https://github.com/servo/stylo/issues/148)

This PR builds on:
- [x] https://github.com/servo/stylo/pull/99
- [x] https://github.com/servo/stylo/pull/150
- [x] https://github.com/servo/stylo/pull/149
- [x] https://github.com/servo/stylo/pull/155

### Notes
- I have gone for a simple versioning scheme where all `stylo*` crates have the same version. This means we don't have to worry about breaking vs. non-breaking changes for subcrates. And it makes it simple for consumers of Stylo to work out which version of the subcrates they ought to be depending on. `selectors` and `servo_arc` are still separately versioned.
- I propose that we (permanently) keep the following diff downstream:
   - Crate version numbers `version = "x.y.z"` line in `Cargo.toml`
   - Dependency lines for *crates that live within this repo* (e.g. `stylo`'s dependency on `stylo_traits`, but NOT `stylo`'s dependency on `cssparser`).
   
   This will allow us to avoid triggering Gecko's/Mozilla's auditing process every time we bump a version number. And we need to maintain some level of diff of for `Cargo.toml` files anyway.
   
### Release Process
- [x] Publish `cssparser` v0.35 (https://github.com/servo/rust-cssparser/pull/404)
- [x] Upgrade the following Stylo crates to use the newly published `cssparser` v0.35 (https://github.com/servo/stylo/pull/155):
   - to_shmem
   - stylo_malloc_size_of
   - selectors
   - stylo_traits
   - stylo
- [x] Merge this PR
- [ ] Publish the crates which have a version bump (everything except `to_shmem_derive` and `servo_arc`). A release order which should work is:
   - [ ] to_shmem (now necessary because of `cssparser` bump)
   - [ ] selectors
   - [ ] stylo_static_prefs
   - [ ] stylo_config
   - [ ] stylo_atoms
   - [ ] stylo_malloc_size_of
   - [ ] stylo_dom
   - [ ] stylo_derive
   - [ ] stylo_traits
   - [ ] stylo

(Servo will also need to be updated to `cssparser` v0.35, but that doesn't block this PR or Stylo release)
   