### PR TITLE
Revert renaming of generic parameter

### DIFF
--- a/style/values/generics/length.rs
+++ b/style/values/generics/length.rs
@@ -75,13 +75,13 @@ impl<LengthPercentage> LengthPercentageOrAuto<LengthPercentage> {
     }
 }
 
-impl<T> LengthPercentageOrAuto<T>
+impl<LengthPercentage> LengthPercentageOrAuto<LengthPercentage>
 where
-    T: Clone,
+    LengthPercentage: Clone,
 {
     /// Resolves `auto` values by calling `f`.
     #[inline]
-    pub fn auto_is(&self, f: impl FnOnce() -> T) -> T {
+    pub fn auto_is(&self, f: impl FnOnce() -> LengthPercentage) -> LengthPercentage {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => length.clone(),
             LengthPercentageOrAuto::Auto => f(),
@@ -90,7 +90,7 @@ where
 
     /// Returns the non-`auto` value, if any.
     #[inline]
-    pub fn non_auto(&self) -> Option<T> {
+    pub fn non_auto(&self) -> Option<LengthPercentage> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(length) => Some(length.clone()),
             LengthPercentageOrAuto::Auto => None,
@@ -98,7 +98,7 @@ where
     }
 
     /// Maps the length of this value.
-    pub fn map<U>(&self, f: impl FnOnce(T) -> U) -> LengthPercentageOrAuto<U> {
+    pub fn map<T>(&self, f: impl FnOnce(LengthPercentage) -> T) -> LengthPercentageOrAuto<T> {
         match self {
             LengthPercentageOrAuto::LengthPercentage(l) => {
                 LengthPercentageOrAuto::LengthPercentage(f(l.clone()))


### PR DESCRIPTION
This is aimed at reducing the diff. We could upstream this, but as this is a non-functional change (and I believe most of the rest of the generic values use this style of long generic names), I propose we just adjust this back to match upstream.

FWIW, the long generic names confused me for a long time: why is it called `LengthPercentage` when it could really be anything? What I realised is that the "generic" values are designed to be generic specifically over the "specified" and "computed" values. So the intent of this code is the `LengthPercentage` parameter is either `values::specified::LengthPercentage` or `values::computed::LengthPercentage`. With that in mind, the `LengthPercentage` name makes more sense I think.