### PR TITLE
Upgrade to cssparser 0.35

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -15,7 +15,7 @@ servo = ["string_cache"]
 
 [dependencies]
 app_units = "0.7"
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f" }
+cssparser = "0.35"
 euclid = "0.22"
 selectors = { path = "../selectors" }
 servo_arc = { path = "../servo_arc" }

--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -21,7 +21,7 @@ to_shmem = ["dep:to_shmem", "dep:to_shmem_derive"]
 
 [dependencies]
 bitflags = "2"
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f" }
+cssparser = "0.35"
 derive_more = { version = "0.99", default-features = false, features = ["add", "add_assign"] }
 fxhash = "0.2"
 log = "0.4"

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -57,7 +57,7 @@ arrayvec = "0.7"
 atomic_refcell = "0.1"
 bitflags = "2"
 byteorder = "1.0"
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f" }
+cssparser = "0.35"
 derive_more = { version = "0.99", default-features = false, features = ["add", "add_assign", "deref", "deref_mut", "from"] }
 dom = { path = "../stylo_dom", version = "0.1", package = "stylo_dom" }
 new_debug_unreachable = "1.0"

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -18,7 +18,7 @@ gecko = []
 [dependencies]
 app_units = "0.7"
 bitflags = "2"
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f" }
+cssparser = "0.35"
 euclid = "0.22"
 malloc_size_of = { path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"

--- a/to_shmem/Cargo.toml
+++ b/to_shmem/Cargo.toml
@@ -23,7 +23,7 @@ string_cache = ["dep:string_cache"]
 thin-vec = ["dep:thin-vec"]
 
 [dependencies]
-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "958a3f098acb92ddacdce18a7ef2c4a87ac3326f", optional = true }
+cssparser = { version = "0.35", optional = true }
 servo_arc = { version = "0.4.0", path = "../servo_arc", optional = true }
 smallbitvec = { version = "2.3.0", optional = true }
 smallvec = { version = "1.13", optional = true }


### PR DESCRIPTION
Stylo was already using the same version of the code as a git dependency. This just pulls it from crates.io.

Servo PR:
- https://github.com/servo/servo/pull/36073