### PR TITLE
Enable `font-variation-settings` property

### DIFF
--- a/style/properties/longhands/font.mako.rs
+++ b/style/properties/longhands/font.mako.rs
@@ -242,7 +242,8 @@ ${helpers.predefined_type(
 ${helpers.predefined_type(
     "font-variation-settings",
     "FontVariationSettings",
-    engines="gecko",
+    engines="gecko servo",
+    servo_pref="layout.unimplemented",
     gecko_pref="layout.css.font-variations.enabled",
     has_effect_on_gecko_scrollbars=False,
     initial_value="computed::FontVariationSettings::normal()",

--- a/style/values/generics/font.rs
+++ b/style/values/generics/font.rs
@@ -84,6 +84,7 @@ where
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct VariationValue<Number> {
     /// A four-character tag, packed into a u32 (one byte per character).
     #[animation(constant)]
@@ -102,6 +103,7 @@ impl<T> TaggedFontValue for VariationValue<T> {
 #[derive(
     Clone, Debug, Eq, MallocSizeOf, PartialEq, SpecifiedValueInfo, ToAnimatedValue, ToCss, ToResolvedValue, ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[css(comma)]
 pub struct FontSettings<T>(#[css(if_empty = "normal", iterable)] pub Box<[T]>);
 
@@ -154,6 +156,7 @@ impl<T: Parse> Parse for FontSettings<T> {
     ToResolvedValue,
     ToShmem,
 )]
+#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct FontTag(pub u32);
 
 impl ToCss for FontTag {


### PR DESCRIPTION
This enables support for controlling the axes of variable fonts. This is currently targeting Blitz whose text stack supports variable fonts. We will definitely also want this in Servo at some point, but for now I've gated this behind the `layout.unimplemented` pref as I believe Servo's font stack does not yet support variable fonts.