### PR TITLE
Enable publishing for all crates in stylo

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/stylo"
-publish = false
 
 [lib]
 path = "lib.rs"

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
-publish = false
 
 build = "build.rs"
 

--- a/style_derive/Cargo.toml
+++ b/style_derive/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
-publish = false
 
 [lib]
 path = "lib.rs"

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
-publish = false
 
 [lib]
 name = "style_traits"


### PR DESCRIPTION
This is important for releasing version `v0.2.0`. See #151.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
