### PR TITLE
Add a description field to crates missing one

### DIFF
--- a/malloc_size_of/Cargo.toml
+++ b/malloc_size_of/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/stylo"
+description = "An allocator-agnostic crate for measuring the heap size of a value"
 
 [lib]
 path = "lib.rs"

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
+description = "The Stylo CSS engine"
 
 build = "build.rs"
 

--- a/style_derive/Cargo.toml
+++ b/style_derive/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
+description = "Derive crate for Stylo CSS engine"
 
 [lib]
 path = "lib.rs"

--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"
 edition = "2021"
+description = "Types used by the Stylo CSS engine"
 
 [lib]
 name = "style_traits"


### PR DESCRIPTION
This is necessary to publish `v0.2.0`.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
