### PR TITLE
Enable parent selector (`&`)

### DIFF
--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -523,7 +523,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
 
     #[inline]
     fn parse_parent_selector(&self) -> bool {
-        false
+        true
     }
 
     #[inline]


### PR DESCRIPTION
This is part of https://github.com/servo/servo/issues/36245

Servo PR: https://github.com/servo/servo/pull/36249