### PR TITLE
Only set PYTHONDONTWRITEBYTECODE env variable for subprocess

### DIFF
--- a/style/build.rs
+++ b/style/build.rs
@@ -53,18 +53,17 @@ fn generate_properties(engine: &str) {
         }
     }
 
-    // `cargo publish` isn't happy with the `__pycache__` files that are created
-    // when we run the property generator.
-    //
-    // TODO(mrobinson): Is this happening because of how we run this script? It
-    // would be better to ensure are just placed in the output directory.
-    env::set_var("PYTHONDONTWRITEBYTECODE", "1");
-
     let script = Path::new(&env::var_os("CARGO_MANIFEST_DIR").unwrap())
         .join("properties")
         .join("build.py");
 
     let status = Command::new(&*PYTHON)
+        // `cargo publish` isn't happy with the `__pycache__` files that are created
+        // when we run the property generator.
+        //
+        // TODO(mrobinson): Is this happening because of how we run this script? It
+        // would be better to ensure are just placed in the output directory.
+        .env("PYTHONDONTWRITEBYTECODE", "1")
         .arg(&script)
         .arg(engine)
         .arg("style-crate")


### PR DESCRIPTION
`env::set_var` has become `unsafe` in the 2024 edition (https://github.com/rust-lang/rust/issues/124866), so best that we avoid it.