### PR TITLE
Prepare for Stylo 0.2.1 release

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"


### PR DESCRIPTION
I know we only just released 0.2.0 (and I'm NOT at all planning to do this for every PR), but it would be super nice to have https://github.com/servo/stylo/pull/164 (parent selector) in the initial Blitz release so I am proposing a patch release for it.

I believe the process should be quite lightweight, just:
- Approve/Merge this PR
- Run `cargo publish` on just the `stylo` crate

(I'm hoping this won't be too controversial!)

