### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,78 @@
 Stylo
 =====
 
-This repo contains Servo’s downstream fork of [Stylo](https://searchfox.org/mozilla-central/source/servo).
+**High-performance CSS style engine**
+
+[![Build Status](https://github.com/servo/stylo/actions/workflows/main.yml/badge.svg)](https://github.com/servo/stylo/actions)
+[![Crates.io](https://img.shields.io/crates/v/stylo.svg)](https://crates.io/crates/stylo)
+[![Docs](https://docs.rs/stylo/badge.svg)](https://docs.rs/stylo)
+![Crates.io License](https://img.shields.io/crates/l/stylo)
+
+Stylo is a high-performance, browser-grade CSS style engine written in Rust that powers [Servo](https://servo.org) and [Firefox](https://firefox.com). This repo contains Servo’s downstream version of Stylo. The upstream version lives in mozilla-central with the rest of the Gecko/Firefox codebase.
+
+Coordination of Stylo development happens:
+
+- Here in Github Issues
+- In the [#stylo](https://servo.zulipchat.com/#narrow/channel/417109-stylo) channel of the [Servo Zulip](https://servo.zulipchat.com/)
+- In the [#layout](https://chat.mozilla.org/#/room/#layout:mozilla.org) room of the Mozilla Matrix instance (matrix.mozilla.org)
+
+## High-level Documentation
+
+- This [Mozilla Hacks article](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo) contains a high-level overview of the Stylo architecture.
+- There is a [chapter](https://book.servo.org/architecture/style.html) in the Servo Book (although it is a little out of date).
+
+## Branches
 
 The branches are as follows:
 
-- [`upstream`](https://github.com/servo/style/tree/upstream) has upstream mozilla-central filtered to the paths we care about ([style.paths](style.paths)), but is otherwise unmodified
-- [`main`](https://github.com/servo/style/tree/ci) has our downstream patches, plus the scripts and workflows for syncing with mozilla-central, to be rebased onto `upstream`
+- [**upstream**](https://github.com/servo/style/tree/upstream) has upstream [mozilla-central](https://searchfox.org/mozilla-central/source/servo) filtered to the paths we care about ([style.paths](style.paths)), but is otherwise unmodified.
+- [**main**](https://github.com/servo/style/tree/ci) adds our downstream patches, plus the scripts and workflows for syncing with mozilla-central on top of **upstream**.
 
-## Building Servo against your local Stylo
+> [!WARNING]
+> This repo syncs from upstream by creating a new branch and then rebasing our changes on top of it. This means that `git pull` will not work across syncs (you will need to use `git fetch`, `git reset` and `git rebase`).
+
+More information on the syncing process is available in [SYNCING.md](SYNCING.md)
+
+## Crates
+
+A guide to the crates contained within this repo
+
+### Stylo Crates
+
+These crates are largely implementation details of Stylo, although you may need to use some of them directly if you use Stylo.
+
+| Directory          | Crate                                                                                                               | Notes                                                                                                             |
+| ---                | ---                                                                                                                 | ---                                                                                                               |
+| style              | [![Crates.io](https://img.shields.io/crates/v/stylo.svg)](https://crates.io/crates/stylo)                           | The main Stylo crate containing the entire CSS engine                                                             |
+| style_traits       | [![Crates.io](https://img.shields.io/crates/v/stylo_traits.svg)](https://crates.io/crates/stylo_traits)             | Types and traits which allow other code to interoperate with Stylo without depending on the main crate directly.  |
+| stylo_dom          | [![Crates.io](https://img.shields.io/crates/v/stylo_dom.svg)](https://crates.io/crates/stylo_dom)                   | Similar to stylo_traits (but much smaller)                                                                        |
+| stylo_atoms        | [![Crates.io](https://img.shields.io/crates/v/stylo_atoms.svg)](https://crates.io/crates/stylo_atoms)               | [Atoms](https://docs.rs/string_cache/latest/string_cache/struct.Atom.html) for CSS and HTML event related strings |
+| stylo_config       | [![Crates.io](https://img.shields.io/crates/v/stylo_config.svg)](https://crates.io/crates/stylo_config)             | Configuration for Stylo. Can be used to set runtime preferences (enabling/disabling properties, etc)              |
+| stylo_static_prefs | [![Crates.io](https://img.shields.io/crates/v/stylo_static_prefs.svg)](https://crates.io/crates/stylo_static_prefs) | Static configuration for Stylo. Config be overridden by patching in a replacement crate.                          |
+| style_derive       | [![Crates.io](https://img.shields.io/crates/v/stylo_derive.svg)](https://crates.io/crates/stylo_derive)             | Internal derive macro for stylo crate                                                                             |
+
+### Standalone crates
+
+These crates form part of Stylo but are also be useful standalone.
+
+| Directory | Crate                                                                                             | Notes                   |
+| ---       | ---                                                                                               | ---                     |
+| selectors | [![Crates.io](https://img.shields.io/crates/v/selectors.svg)](https://crates.io/crates/selectors) | CSS Selector matching   |
+| servo_arc | [![Crates.io](https://img.shields.io/crates/v/servo_arc.svg)](https://crates.io/crates/servo_arc) | A variant on `std::Arc` |
+
+You may also be interested in the `cssparser` crate which lives in the [servo/rust-cssparser](https://github.com/servo/rust-cssparser) repo.
+
+### Support crates
+
+Low-level crates which could technically be used standalone but are unlikely to be generally useful in practice.
+
+| Directory       | Crate                                                                                                                   | Notes                                                       |
+| ---             | ---                                                                                                                     | ---                                                         |
+| malloc_size_of  | [![Crates.io](https://img.shields.io/crates/v/stylo_malloc_size_of.svg)](https://crates.io/crates/stylo_malloc_size_of) | Heap size measurement for Stylo values                      |
+| to_shmem        | [![Crates.io](https://img.shields.io/crates/v/to_shmem.svg)](https://crates.io/crates/to_shmem)                         | Internal utility crate for sharing memory across processes. |
+| to_shmem_derive | [![Crates.io](https://img.shields.io/crates/v/to_shmem_derive.svg)](https://crates.io/crates/to_shmem_derive)           | Internal derive macro for to_shmem crate                    |
+
+## Building Servo against a local copy of Stylo
 
 Assuming your local `servo` and `stylo` directories are siblings, you can build `servo` against `stylo` by adding the following to `servo/Cargo.toml`:
 
@@ -24,62 +88,6 @@ stylo_malloc_size_of = { path = "../stylo/malloc_size_of" }
 stylo_traits = { path = "../stylo/style_traits" }
 ```
 
-## Syncing `upstream` with mozilla-central
+## License
 
-Start by generating a filtered copy of mozilla-central. This will cache the raw mozilla-central in `_cache/upstream`, storing the result in `_filtered`:
-
-```sh
-$ ./sync.sh _filtered
-```
-
-If `_filtered` already exists, you will need to delete it and try again:
-
-```sh
-$ rm -Rf _filtered
-```
-
-Now overwrite our `upstream` with those commits and push:
-
-```sh
-$ git fetch -f --progress ./_filtered master:upstream
-$ git push -fu --progress origin upstream
-```
-
-## Rebasing `main` onto `upstream`
-
-Start by fetching `upstream` into your local repo:
-
-```sh
-$ git fetch -f origin upstream:upstream
-```
-
-In general, the filtering process is deterministic, yielding the same commit hashes each time, so we can rebase normally:
-
-```sh
-$ git rebase upstream
-```
-
-But if the filtering config changes or Mozilla moves to GitHub, the commit hashes on `upstream` may change. In this case, we need to tell git where the old upstream ends and our own commits start (notice the `~`):
-
-```sh
-$ git log --pretty=\%H --grep='Servo initial downstream commit'
-e62d7f0090941496e392e1dc91df103a38e3f488
-
-$ git rebase --onto upstream e62d7f0090941496e392e1dc91df103a38e3f488~
-Successfully rebased and updated refs/heads/main.
-```
-
-`start-rebase.sh` takes care of this automatically, but you should still use `git rebase` for subsequent steps like `--continue` and `--abort`:
-
-```sh
-$ ./start-rebase.sh upstream
-$ ./start-rebase.sh upstream -i     # interactive
-$ git rebase --continue             # not ./start-rebase.sh --continue
-$ git rebase --abort                # not ./start-rebase.sh --abort
-```
-
-Or if we aren’t ready to rebase onto the tip of upstream:
-
-```sh
-$ ./start-rebase.sh upstream~10 -i
-```
+Stylo is licensed under MPL 2.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Stylo
 =====
 
-**High-performance CSS style engine**
+**High-Performance CSS Style Engine**
 
 [![Build Status](https://github.com/servo/stylo/actions/workflows/main.yml/badge.svg)](https://github.com/servo/stylo/actions)
 [![Crates.io](https://img.shields.io/crates/v/stylo.svg)](https://crates.io/crates/stylo)
@@ -16,7 +16,7 @@ Coordination of Stylo development happens:
 - In the [#stylo](https://servo.zulipchat.com/#narrow/channel/417109-stylo) channel of the [Servo Zulip](https://servo.zulipchat.com/)
 - In the [#layout](https://chat.mozilla.org/#/room/#layout:mozilla.org) room of the Mozilla Matrix instance (matrix.mozilla.org)
 
-## High-level Documentation
+## High-Level Documentation
 
 - This [Mozilla Hacks article](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo) contains a high-level overview of the Stylo architecture.
 - There is a [chapter](https://book.servo.org/architecture/style.html) in the Servo Book (although it is a little out of date).
@@ -51,7 +51,7 @@ These crates are largely implementation details of Stylo, although you may need 
 | stylo_static_prefs | [![Crates.io](https://img.shields.io/crates/v/stylo_static_prefs.svg)](https://crates.io/crates/stylo_static_prefs) | Static configuration for Stylo. Config be overridden by patching in a replacement crate.                          |
 | style_derive       | [![Crates.io](https://img.shields.io/crates/v/stylo_derive.svg)](https://crates.io/crates/stylo_derive)             | Internal derive macro for stylo crate                                                                             |
 
-### Standalone crates
+### Standalone Crates
 
 These crates form part of Stylo but are also be useful standalone.
 
@@ -62,7 +62,7 @@ These crates form part of Stylo but are also be useful standalone.
 
 You may also be interested in the `cssparser` crate which lives in the [servo/rust-cssparser](https://github.com/servo/rust-cssparser) repo.
 
-### Support crates
+### Support Crates
 
 Low-level crates which could technically be used standalone but are unlikely to be generally useful in practice.
 
@@ -72,7 +72,7 @@ Low-level crates which could technically be used standalone but are unlikely to 
 | to_shmem        | [![Crates.io](https://img.shields.io/crates/v/to_shmem.svg)](https://crates.io/crates/to_shmem)                         | Internal utility crate for sharing memory across processes. |
 | to_shmem_derive | [![Crates.io](https://img.shields.io/crates/v/to_shmem_derive.svg)](https://crates.io/crates/to_shmem_derive)           | Internal derive macro for to_shmem crate                    |
 
-## Building Servo against a local copy of Stylo
+## Building Servo Against a Local Copy of Stylo
 
 Assuming your local `servo` and `stylo` directories are siblings, you can build `servo` against `stylo` by adding the following to `servo/Cargo.toml`:
 

--- a/SYNCING.md
+++ b/SYNCING.md
@@ -1,0 +1,63 @@
+# Syncing
+
+This file documents the process of syncing this repository with the upstream copy of Stylo in mozilla-central.
+
+## Syncing `upstream` with mozilla-central
+
+Start by generating a filtered copy of mozilla-central. This will cache the raw mozilla-central in `_cache/upstream`, storing the result in `_filtered`:
+
+```sh
+$ ./sync.sh _filtered
+```
+
+If `_filtered` already exists, you will need to delete it and try again:
+
+```sh
+$ rm -Rf _filtered
+```
+
+Now overwrite our `upstream` with those commits and push:
+
+```sh
+$ git fetch -f --progress ./_filtered master:upstream
+$ git push -fu --progress origin upstream
+```
+
+## Rebasing `main` onto `upstream`
+
+Start by fetching `upstream` into your local repo:
+
+```sh
+$ git fetch -f origin upstream:upstream
+```
+
+In general, the filtering process is deterministic, yielding the same commit hashes each time, so we can rebase normally:
+
+```sh
+$ git rebase upstream
+```
+
+But if the filtering config changes or Mozilla moves to GitHub, the commit hashes on `upstream` may change. In this case, we need to tell git where the old upstream ends and our own commits start (notice the `~`):
+
+```sh
+$ git log --pretty=\%H --grep='Servo initial downstream commit'
+e62d7f0090941496e392e1dc91df103a38e3f488
+
+$ git rebase --onto upstream e62d7f0090941496e392e1dc91df103a38e3f488~
+Successfully rebased and updated refs/heads/main.
+```
+
+`start-rebase.sh` takes care of this automatically, but you should still use `git rebase` for subsequent steps like `--continue` and `--abort`:
+
+```sh
+$ ./start-rebase.sh upstream
+$ ./start-rebase.sh upstream -i     # interactive
+$ git rebase --continue             # not ./start-rebase.sh --continue
+$ git rebase --abort                # not ./start-rebase.sh --abort
+```
+
+Or if we aren’t ready to rebase onto the tip of upstream:
+
+```sh
+$ ./start-rebase.sh upstream~10 -i
+```


### PR DESCRIPTION
This new version aims to be useful to a general audience who may not be familiar with Stylo. The syncing instructions have been moved to a separate file as they are only really useful for maintainers.

[Rendered](https://github.com/nicoburns/stylo/blob/68c870c202a5585981848b2ececf9c515f266ec6/README.md)