### PR TITLE
Box `PaintWorklet` to reduce `GenericImage` size

### DIFF
--- a/style/properties/longhands/border.mako.rs
+++ b/style/properties/longhands/border.mako.rs
@@ -112,7 +112,6 @@ ${helpers.predefined_type(
     spec="https://drafts.csswg.org/css-backgrounds/#the-background-image",
     vector=False,
     animation_type="discrete",
-    boxed=engine == "servo",
     ignored_when_colors_disabled=True,
     affects="paint",
 )}

--- a/style/properties/longhands/list.mako.rs
+++ b/style/properties/longhands/list.mako.rs
@@ -59,7 +59,6 @@ ${helpers.predefined_type(
     initial_specified_value="specified::Image::None",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists/#propdef-list-style-image",
-    boxed=engine == "servo",
     servo_restyle_damage="rebuild_and_reflow",
     affects="layout",
 )}

--- a/style/values/computed/image.rs
+++ b/style/values/computed/image.rs
@@ -32,7 +32,7 @@ pub type Image = generic::GenericImage<Gradient, ComputedUrl, Color, Percentage,
 #[cfg(feature = "gecko")]
 size_of_test!(Image, 16);
 #[cfg(feature = "servo")]
-size_of_test!(Image, 40);
+size_of_test!(Image, 24);
 
 /// Computed values for a CSS gradient.
 /// <https://drafts.csswg.org/css-images/#gradients>

--- a/style/values/generics/image.rs
+++ b/style/values/generics/image.rs
@@ -42,7 +42,7 @@ pub enum GenericImage<G, ImageUrl, Color, Percentage, Resolution> {
     /// A paint worklet image.
     /// <https://drafts.css-houdini.org/css-paint-api/>
     #[cfg(feature = "servo")]
-    PaintWorklet(PaintWorklet),
+    PaintWorklet(Box<PaintWorklet>),
 
     /// A `<cross-fade()>` image. Storing this directly inside of
     /// GenericImage increases the size by 8 bytes so we box it here

--- a/style/values/specified/image.rs
+++ b/style/values/specified/image.rs
@@ -46,7 +46,7 @@ pub type Image = generic::Image<Gradient, SpecifiedUrl, Color, Percentage, Resol
 #[cfg(feature = "gecko")]
 size_of_test!(Image, 16);
 #[cfg(feature = "servo")]
-size_of_test!(Image, 40);
+size_of_test!(Image, 24);
 
 /// Specified values for a CSS gradient.
 /// <https://drafts.csswg.org/css-images/#gradients>
@@ -244,7 +244,7 @@ impl Image {
         input.parse_nested_block(|input| {
             Ok(match_ignore_ascii_case! { &function,
                 #[cfg(feature = "servo")]
-                "paint" => Self::PaintWorklet(PaintWorklet::parse_args(context, input)?),
+                "paint" => Self::PaintWorklet(Box::new(<PaintWorklet>::parse_args(context, input)?)),
                 "cross-fade" if cross_fade_enabled() => Self::CrossFade(Box::new(CrossFade::parse_args(context, input, cors_mode, flags)?)),
                 #[cfg(feature = "gecko")]
                 "-moz-element" => Self::Element(Self::parse_element(input)?),


### PR DESCRIPTION
Closes #146. Reduces the size of `GenericImage` from 40 to 24 bytes by boxing `PaintWorklet` variant. 