### PR TITLE
Add before toggle atom

### DIFF
--- a/stylo_atoms/static_atoms.txt
+++ b/stylo_atoms/static_atoms.txt
@@ -19,6 +19,7 @@ animationend
 animationiteration
 animationstart
 aspect-ratio
+beforetoggle
 beforeunload
 block-size
 button


### PR DESCRIPTION
This is needed for the `beforetoggle` event for `details`, `dialog` & `popover`.