### PR TITLE
Use web_atoms crate

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -35,7 +35,7 @@ servo = [
     "cssparser/serde",
     "encoding_rs",
     "malloc_size_of/servo",
-    "markup5ever",
+    "web_atoms",
     "mime",
     "serde",
     "servo_arc/servo",
@@ -72,7 +72,7 @@ lazy_static = "1"
 log = "0.4"
 malloc_size_of = { version = "0.2", path = "../malloc_size_of", package = "stylo_malloc_size_of" }
 malloc_size_of_derive = "0.1"
-markup5ever = { version = "0.16", optional = true }
+web_atoms = { version = "0.1", optional = true }
 matches = "0.1"
 mime = { version = "0.3.13", optional = true }
 num_cpus = {version = "1.1.0"}

--- a/style/lib.rs
+++ b/style/lib.rs
@@ -48,8 +48,7 @@ extern crate malloc_size_of;
 #[macro_use]
 extern crate malloc_size_of_derive;
 #[cfg(feature = "servo")]
-#[macro_use]
-extern crate markup5ever;
+extern crate web_atoms;
 #[allow(unused_extern_crates)]
 #[macro_use]
 extern crate matches;
@@ -159,13 +158,13 @@ pub use stylo_atoms::Atom;
 
 #[cfg(feature = "servo")]
 #[allow(missing_docs)]
-pub type LocalName = crate::values::GenericAtomIdent<markup5ever::LocalNameStaticSet>;
+pub type LocalName = crate::values::GenericAtomIdent<web_atoms::LocalNameStaticSet>;
 #[cfg(feature = "servo")]
 #[allow(missing_docs)]
-pub type Namespace = crate::values::GenericAtomIdent<markup5ever::NamespaceStaticSet>;
+pub type Namespace = crate::values::GenericAtomIdent<web_atoms::NamespaceStaticSet>;
 #[cfg(feature = "servo")]
 #[allow(missing_docs)]
-pub type Prefix = crate::values::GenericAtomIdent<markup5ever::PrefixStaticSet>;
+pub type Prefix = crate::values::GenericAtomIdent<web_atoms::PrefixStaticSet>;
 
 pub use style_traits::arc_slice::ArcSlice;
 pub use style_traits::owned_slice::OwnedSlice;

--- a/style/macros.rs
+++ b/style/macros.rs
@@ -41,17 +41,17 @@ macro_rules! try_match_ident_ignore_ascii_case {
 #[cfg(feature = "servo")]
 macro_rules! local_name {
     ($s:tt) => {
-        $crate::values::GenericAtomIdent(markup5ever::local_name!($s))
+        $crate::values::GenericAtomIdent(web_atoms::local_name!($s))
     };
 }
 
 #[cfg(feature = "servo")]
 macro_rules! ns {
     () => {
-        $crate::values::GenericAtomIdent(markup5ever::ns!())
+        $crate::values::GenericAtomIdent(web_atoms::ns!())
     };
     ($s:tt) => {
-        $crate::values::GenericAtomIdent(markup5ever::ns!($s))
+        $crate::values::GenericAtomIdent(web_atoms::ns!($s))
     };
 }
 

--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -500,8 +500,8 @@ impl ::selectors::SelectorImpl for SelectorImpl {
     type LocalName = LocalName;
     type NamespacePrefix = Prefix;
     type NamespaceUrl = Namespace;
-    type BorrowedLocalName = markup5ever::LocalName;
-    type BorrowedNamespaceUrl = markup5ever::Namespace;
+    type BorrowedLocalName = web_atoms::LocalName;
+    type BorrowedNamespaceUrl = web_atoms::Namespace;
 }
 
 impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {


### PR DESCRIPTION
See https://github.com/servo/html5ever/pull/599. This should mean much less synchronisation across repos when doing html5ever upgrades. We could also consider merging the `stylo_atoms` crate into the new `web_atoms` crate which would save us maintaining it as a "diff" here.