### PR TITLE
servo_arc: make track_alloc_size feature a default feature

### DIFF
--- a/servo_arc/Cargo.toml
+++ b/servo_arc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "servo_arc"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The Servo Project Developers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/servo/stylo"
@@ -12,6 +12,7 @@ name = "servo_arc"
 path = "lib.rs"
 
 [features]
+default = ["track_alloc_size"]
 gecko_refcount_logging = []
 servo = ["serde", "track_alloc_size"]
 track_alloc_size = []


### PR DESCRIPTION
## Objective

Fixes https://github.com/servo/stylo/issues/129 for users that have default features enabled (and it will be the only default feature so there's no reason not to have default features enabled).

## Changes made
- Made `track_alloc_size` feature a default feature
- Bumped version of `servo_arc` to `0.4.1`

## Alternatives
Arguably ought to be the behaviour with no features enabled, and there ought to be a `dont_track_alloc_size` feature that disables the tracking for Gecko (I believe the combination of having this disabled and using an allocator that requires accurate tracking is actually UB), but this is the simpler change that will likely fix the problem for almost everyone in practice.