### PR TITLE
Make `RestyleDamage` much simpler for Servo

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -2214,40 +2214,6 @@ impl ComputedValuesInner {
             box_.transform_style
         }
     }
-
-    /// Whether given this transform value, the compositor would require a
-    /// layer.
-    pub fn transform_requires_layer(&self) -> bool {
-        use crate::values::generics::transform::TransformOperation;
-        // Check if the transform matrix is 2D or 3D
-        for transform in &*self.get_box().transform.0 {
-            match *transform {
-                TransformOperation::Perspective(..) => {
-                    return true;
-                }
-                TransformOperation::Matrix3D(m) => {
-                    // See http://dev.w3.org/csswg/css-transforms/#2d-matrix
-                    if m.m31 != 0.0 || m.m32 != 0.0 ||
-                       m.m13 != 0.0 || m.m23 != 0.0 ||
-                       m.m43 != 0.0 || m.m14 != 0.0 ||
-                       m.m24 != 0.0 || m.m34 != 0.0 ||
-                       m.m33 != 1.0 || m.m44 != 1.0 {
-                        return true;
-                    }
-                }
-                TransformOperation::Translate3D(_, _, z) |
-                TransformOperation::TranslateZ(z) => {
-                    if z.px() != 0. {
-                        return true;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // Neither perspective nor transform present
-        false
-    }
 }
 
 /// A reference to a style struct of the parent, or our own style struct.


### PR DESCRIPTION
Servo is currently rewriting the incremental layout system. Many
`RestyleDamage` variants only applied to the old layout system, so
only keep the variants that Servo will need for the first part of
incremental layout.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
