### PR TITLE
Make the default Servo restyle damage be `rebuild_and_reflow`

### DIFF
--- a/style/properties/data.py
+++ b/style/properties/data.py
@@ -373,7 +373,7 @@ class Longhand(Property):
         ignored_when_colors_disabled=False,
         simple_vector_bindings=False,
         vector=False,
-        servo_restyle_damage="repaint",
+        servo_restyle_damage="rebuild_and_reflow",
         affects=None,
     ):
         Property.__init__(


### PR DESCRIPTION
When a property has no restyle damage specified, to ensure proper
behavior, it's better to be conservative and do a full reflow. That way,
the addition of the `servo_restyle_damage` setting can improve the
performacne of layout, but its absence can never break layout.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
Co-authored-by: Oriol Brufau <obrufau@igalia.com>
