### PR TITLE
Further refine Servo's repaint-only restyle damage

### DIFF
--- a/style/properties/longhands/inherited_ui.mako.rs
+++ b/style/properties/longhands/inherited_ui.mako.rs
@@ -23,6 +23,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty",
+    servo_restyle_damage="repaint",
     affects="paint",
 )}
 

--- a/style/properties/longhands/svg.mako.rs
+++ b/style/properties/longhands/svg.mako.rs
@@ -82,7 +82,6 @@ ${helpers.predefined_type(
     engines="gecko servo",
     extra_prefixes="webkit",
     spec="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path",
-    servo_restyle_damage="repaint",
     affects="paint",
 )}
 


### PR DESCRIPTION
- Make changes to `clip-path` no longer cause repaint-only restyle damage,
  as we are splitting out stacking context tree building from display list
  building and `clip-path` can cause stacking context tree changes.

- Changes to `pointer-events` can be processed during display list building and are
  thus repaint only.

Co-authored-by: Oriol Brufau <obrufau@igalia.com>
Signed-off-by: Martin Robinson <mrobinson@igalia.com>
