### PR TITLE
Use firefox repo as upstream

### DIFF
--- a/SYNCING.md
+++ b/SYNCING.md
@@ -19,7 +19,7 @@ $ rm -Rf _filtered
 Now overwrite our `upstream` with those commits and push:
 
 ```sh
-$ git fetch -f --progress ./_filtered master:upstream
+$ git fetch -f --progress ./_filtered main:upstream
 $ git push -fu --progress origin upstream
 ```
 

--- a/sync.sh
+++ b/sync.sh
@@ -30,7 +30,7 @@ fi
 
 step Cloning upstream if needed
 if ! [ -e upstream ]; then
-    git clone --bare --single-branch --progress https://github.com/mozilla/gecko-dev.git upstream
+    git clone --bare --single-branch --progress https://github.com/mozilla-firefox/firefox.git upstream
 fi
 
 step Updating upstream


### PR DESCRIPTION
- Fixes #184

Mozilla have deprecated https://github.com/mozilla/gecko-dev in favour of https://github.com/mozilla-firefox/firefox. This PR switches our syncing code over to the new repo.

A one-off manual deletion of local `_cache` and `_filtered` directories will be required to use this PR.

I have run the sync script in this PR and pushed the result to the [ffupstream](https://github.com/servo/stylo/tree/ffupstream) branch for reference.