### PR TITLE
Add `ServoRestyleDamage::REBUILD_STACKING_CONTEXT`

### DIFF
--- a/style/properties/data.py
+++ b/style/properties/data.py
@@ -373,7 +373,7 @@ class Longhand(Property):
         ignored_when_colors_disabled=False,
         simple_vector_bindings=False,
         vector=False,
-        servo_restyle_damage="rebuild_and_reflow",
+        servo_restyle_damage="rebuild_box",
         affects=None,
     ):
         Property.__init__(

--- a/style/properties/longhands/border.mako.rs
+++ b/style/properties/longhands/border.mako.rs
@@ -52,7 +52,7 @@
         logical=is_logical,
         logical_group="border-width",
         allow_quirks="No" if is_logical else "Yes",
-        servo_restyle_damage="reflow rebuild_and_reflow_inline",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endfor

--- a/style/properties/longhands/box.mako.rs
+++ b/style/properties/longhands/box.mako.rs
@@ -13,7 +13,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::Display::inline()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-display/#propdef-display",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -49,7 +49,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::PositionProperty::Static",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-position/#position-property",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -86,7 +86,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-box/#propdef-float",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -97,7 +97,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css2/#propdef-clear",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -107,7 +107,7 @@ ${helpers.predefined_type(
     "computed::VerticalAlign::baseline()",
     engines="gecko servo",
     spec="https://www.w3.org/TR/CSS2/visudet.html#propdef-vertical-align",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -118,7 +118,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-inline-3/#baseline-source",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -161,7 +161,7 @@ ${helpers.single_keyword(
         logical=logical,
         animation_type="discrete",
         spec="https://drafts.csswg.org/css-overflow-3/#propdef-{}".format(full_name),
-        servo_restyle_damage = "reflow",
+        servo_restyle_damage = "rebuild_box",
         affects="layout",
     )}
 % endfor
@@ -188,7 +188,7 @@ ${helpers.predefined_type(
     extra_prefixes=transform_extra_prefixes,
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.csswg.org/css-transforms/#propdef-transform",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -200,7 +200,7 @@ ${helpers.predefined_type(
     boxed=True,
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.csswg.org/css-transforms-2/#individual-transforms",
-    servo_restyle_damage = "reflow_out_of_flow",
+    servo_restyle_damage = "rebuild_box",
     affects="overflow",
 )}
 
@@ -212,7 +212,7 @@ ${helpers.predefined_type(
     boxed=True,
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.csswg.org/css-transforms-2/#individual-transforms",
-    servo_restyle_damage = "reflow_out_of_flow",
+    servo_restyle_damage = "rebuild_box",
     affects="overflow",
 )}
 
@@ -224,7 +224,7 @@ ${helpers.predefined_type(
     boxed=True,
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.csswg.org/css-transforms-2/#individual-transforms",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -237,7 +237,7 @@ ${helpers.predefined_type(
     servo_pref="layout.unimplemented",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.fxtf.org/motion-1/#offset-path-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -249,7 +249,7 @@ ${helpers.predefined_type(
     engines="gecko",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.fxtf.org/motion-1/#offset-distance-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -261,7 +261,7 @@ ${helpers.predefined_type(
     engines="gecko",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.fxtf.org/motion-1/#offset-rotate-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -273,7 +273,7 @@ ${helpers.predefined_type(
     engines="gecko",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.fxtf.org/motion-1/#offset-anchor-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     boxed=True,
     affects="overflow",
 )}
@@ -286,7 +286,7 @@ ${helpers.predefined_type(
     engines="gecko",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.fxtf.org/motion-1/#offset-position-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     boxed=True,
     affects="overflow",
 )}
@@ -358,6 +358,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleIsolation",
     animation_type="discrete",
     affects="paint",
+    servo_restyle_damage="repaint",
 )}
 
 ${helpers.predefined_type(
@@ -411,7 +412,7 @@ ${helpers.predefined_type(
     gecko_ffi_name="mChildPerspective",
     spec="https://drafts.csswg.org/css-transforms/#perspective",
     extra_prefixes=transform_extra_prefixes,
-    servo_restyle_damage = "reflow_out_of_flow",
+    servo_restyle_damage = "rebuild_box",
     affects="overflow",
 )}
 
@@ -423,7 +424,7 @@ ${helpers.predefined_type(
     boxed=True,
     extra_prefixes=transform_extra_prefixes,
     spec="https://drafts.csswg.org/css-transforms-2/#perspective-origin-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 
@@ -456,7 +457,7 @@ ${helpers.predefined_type(
     spec="https://drafts.csswg.org/css-transforms-2/#transform-style-property",
     extra_prefixes=transform_extra_prefixes,
     animation_type="discrete",
-    servo_restyle_damage = "reflow_out_of_flow",
+    servo_restyle_damage = "rebuild_box",
     affects="overflow",
 )}
 
@@ -469,7 +470,7 @@ ${helpers.predefined_type(
     gecko_ffi_name="mTransformOrigin",
     boxed=True,
     spec="https://drafts.csswg.org/css-transforms/#transform-origin-property",
-    servo_restyle_damage="reflow_out_of_flow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 

--- a/style/properties/longhands/column.mako.rs
+++ b/style/properties/longhands/column.mako.rs
@@ -12,7 +12,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::length::NonNegativeLengthOrAuto::auto()",
     servo_pref="layout.columns.enabled",
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-width",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -24,7 +24,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::ColumnCount::Auto",
     servo_pref="layout.columns.enabled",
     spec="https://drafts.csswg.org/css-multicol/#propdef-column-count",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/counters.mako.rs
+++ b/style/properties/longhands/counters.mako.rs
@@ -12,7 +12,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::Content::normal()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-content/#propdef-content",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -24,7 +24,7 @@ ${helpers.predefined_type(
     initial_value="Default::default()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists/#propdef-counter-increment",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -36,7 +36,7 @@ ${helpers.predefined_type(
     initial_value="Default::default()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists-3/#propdef-counter-reset",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -47,6 +47,6 @@ ${helpers.predefined_type(
     initial_value="Default::default()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists-3/#propdef-counter-set",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}

--- a/style/properties/longhands/effects.mako.rs
+++ b/style/properties/longhands/effects.mako.rs
@@ -11,7 +11,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     flags="CAN_ANIMATE_ON_COMPOSITOR",
     spec="https://drafts.csswg.org/css-color/#transparency",
-    servo_restyle_damage = "reflow_out_of_flow",
+    servo_restyle_damage="repaint",
     affects="paint",
 )}
 
@@ -81,4 +81,5 @@ ${helpers.single_keyword(
     animation_type="discrete",
     spec="https://drafts.fxtf.org/compositing/#propdef-mix-blend-mode",
     affects="paint",
+    servo_restyle_damage="repaint",
 )}

--- a/style/properties/longhands/font.mako.rs
+++ b/style/properties/longhands/font.mako.rs
@@ -13,7 +13,7 @@ ${helpers.predefined_type(
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-family",
     gecko_ffi_name="mFont.family",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -25,7 +25,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::FontStyle::normal()",
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-style",
     gecko_ffi_name="mFont.style",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -45,7 +45,7 @@ ${helpers.single_keyword(
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-variant-caps",
     custom_consts=font_variant_caps_custom_consts,
     animation_type="discrete",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -57,7 +57,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::FontWeight::normal()",
     gecko_ffi_name="mFont.weight",
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-weight",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -69,7 +69,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::FontSize::medium()",
     allow_quirks="Yes",
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-size",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -140,7 +140,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::FontStretch::normal()",
     gecko_ffi_name="mFont.stretch",
     spec="https://drafts.csswg.org/css-fonts/#propdef-font-stretch",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -359,7 +359,7 @@ ${helpers.predefined_type(
     "computed::LineHeight::normal()",
     engines="gecko servo",
     spec="https://drafts.csswg.org/css2/visudet.html#propdef-line-height",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/inherited_box.mako.rs
+++ b/style/properties/longhands/inherited_box.mako.rs
@@ -29,7 +29,7 @@ ${helpers.single_keyword(
     animation_type="none",
     spec="https://drafts.csswg.org/css-writing-modes/#propdef-writing-mode",
     gecko_enum_prefix="StyleWritingModeProperty",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -40,7 +40,7 @@ ${helpers.single_keyword(
     animation_type="none",
     spec="https://drafts.csswg.org/css-writing-modes/#propdef-direction",
     gecko_enum_prefix="StyleDirection",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/inherited_table.mako.rs
+++ b/style/properties/longhands/inherited_table.mako.rs
@@ -11,7 +11,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleBorderCollapse",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-tables/#propdef-border-collapse",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -22,7 +22,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleEmptyCells",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-tables/#propdef-empty-cells",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="paint",
 )}
 
@@ -33,7 +33,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-tables/#propdef-caption-side",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -44,6 +44,6 @@ ${helpers.predefined_type(
     engines="gecko servo",
     boxed=True,
     spec="https://drafts.csswg.org/css-tables/#propdef-border-spacing",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}

--- a/style/properties/longhands/inherited_text.mako.rs
+++ b/style/properties/longhands/inherited_text.mako.rs
@@ -24,7 +24,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text/#propdef-text-transform",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -58,7 +58,7 @@ ${helpers.predefined_type(
     "computed::TextIndent::zero()",
     engines="gecko servo",
     spec="https://drafts.csswg.org/css-text/#propdef-text-indent",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -72,7 +72,7 @@ ${helpers.predefined_type(
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text/#propdef-overflow-wrap",
     aliases="word-wrap",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -83,7 +83,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text/#propdef-word-break",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -94,7 +94,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text/#propdef-text-justify",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -116,7 +116,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text/#propdef-text-align",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -126,7 +126,7 @@ ${helpers.predefined_type(
     "computed::LetterSpacing::normal()",
     engines="gecko servo",
     spec="https://drafts.csswg.org/css-text/#propdef-letter-spacing",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -136,7 +136,7 @@ ${helpers.predefined_type(
     "computed::WordSpacing::zero()",
     engines="gecko servo",
     spec="https://drafts.csswg.org/css-text/#propdef-word-spacing",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -150,7 +150,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleWhiteSpaceCollapse",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text-4/#propdef-white-space-collapse",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -297,7 +297,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleTextRendering",
     animation_type="discrete",
     spec="https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -384,7 +384,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleTextWrapMode",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text-4/#propdef-text-wrap-mode",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/list.mako.rs
+++ b/style/properties/longhands/list.mako.rs
@@ -11,7 +11,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleListStylePosition",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists/#propdef-list-style-position",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -33,7 +33,7 @@ ${helpers.single_keyword(
         engines="servo",
         animation_type="discrete",
         spec="https://drafts.csswg.org/css-lists/#propdef-list-style-type",
-        servo_restyle_damage="rebuild_and_reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endif
@@ -46,7 +46,7 @@ ${helpers.single_keyword(
         initial_specified_value="specified::ListStyleType::disc()",
         animation_type="discrete",
         spec="https://drafts.csswg.org/css-lists/#propdef-list-style-type",
-        servo_restyle_damage="rebuild_and_reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endif
@@ -59,7 +59,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::Image::None",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-lists/#propdef-list-style-image",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -70,6 +70,6 @@ ${helpers.predefined_type(
     engines="gecko servo",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-content/#propdef-quotes",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}

--- a/style/properties/longhands/margin.mako.rs
+++ b/style/properties/longhands/margin.mako.rs
@@ -23,7 +23,7 @@
         gecko_ffi_name="mMargin.{}".format(index),
         spec=spec,
         rule_types_allowed=(DEFAULT_RULES if side[1] else DEFAULT_RULES_AND_PAGE) | POSITION_TRY_RULE,
-        servo_restyle_damage="reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endfor

--- a/style/properties/longhands/padding.mako.rs
+++ b/style/properties/longhands/padding.mako.rs
@@ -22,7 +22,7 @@
         spec=spec,
         gecko_ffi_name="mPadding.{}".format(index),
         allow_quirks="No" if side[1] else "Yes",
-        servo_restyle_damage="reflow rebuild_and_reflow_inline",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endfor

--- a/style/properties/longhands/position.mako.rs
+++ b/style/properties/longhands/position.mako.rs
@@ -16,7 +16,7 @@
         allow_quirks="Yes",
         rule_types_allowed=DEFAULT_RULES_AND_POSITION_TRY,
         gecko_ffi_name="mOffset.{}".format(index),
-        servo_restyle_damage="reflow_out_of_flow",
+        servo_restyle_damage="rebuild_box",
         logical_group="inset",
         affects="layout",
     )}
@@ -43,6 +43,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     spec="https://www.w3.org/TR/CSS2/visuren.html#z-index",
     affects="paint",
+    servo_restyle_damage="rebuild_stacking_context",
 )}
 
 // CSS Flexible Box Layout Module Level 1
@@ -57,7 +58,7 @@ ${helpers.single_keyword(
     spec="https://drafts.csswg.org/css-flexbox/#flex-direction-property",
     extra_prefixes="webkit",
     animation_type="discrete",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     gecko_enum_prefix = "StyleFlexDirection",
     affects="layout",
 )}
@@ -70,7 +71,7 @@ ${helpers.single_keyword(
     spec="https://drafts.csswg.org/css-flexbox/#flex-wrap-property",
     extra_prefixes="webkit",
     animation_type="discrete",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     gecko_enum_prefix = "StyleFlexWrap",
     affects="layout",
 )}
@@ -83,7 +84,7 @@ ${helpers.predefined_type(
     spec="https://drafts.csswg.org/css-align/#propdef-justify-content",
     extra_prefixes="webkit",
     animation_type="discrete",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -95,7 +96,7 @@ ${helpers.predefined_type(
     spec="https://drafts.csswg.org/css-align/#propdef-align-content",
     extra_prefixes="webkit",
     animation_type="discrete",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -107,7 +108,7 @@ ${helpers.predefined_type(
     spec="https://drafts.csswg.org/css-align/#propdef-align-items",
     extra_prefixes="webkit",
     animation_type="discrete",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -129,7 +130,7 @@ ${helpers.predefined_type(
     engines="gecko servo",
     spec="https://drafts.csswg.org/css-flexbox/#flex-grow-property",
     extra_prefixes="webkit",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -141,7 +142,7 @@ ${helpers.predefined_type(
     servo_pref="layout.flexbox.enabled",
     spec="https://drafts.csswg.org/css-flexbox/#flex-shrink-property",
     extra_prefixes="webkit",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -177,7 +178,7 @@ ${helpers.predefined_type(
     servo_pref="layout.flexbox.enabled",
     extra_prefixes="webkit",
     spec="https://drafts.csswg.org/css-flexbox/#order-property",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -189,7 +190,7 @@ ${helpers.predefined_type(
     servo_pref="layout.flexbox.enabled",
     spec="https://drafts.csswg.org/css-flexbox/#flex-basis-property",
     extra_prefixes="webkit",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     boxed=True,
     affects="layout",
 )}
@@ -211,7 +212,7 @@ ${helpers.predefined_type(
         allow_quirks="No" if logical else "Yes",
         spec=spec % size,
         rule_types_allowed=DEFAULT_RULES_AND_POSITION_TRY,
-        servo_restyle_damage="reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
     // min-width, min-height, min-block-size, min-inline-size
@@ -225,7 +226,7 @@ ${helpers.predefined_type(
         allow_quirks="No" if logical else "Yes",
         spec=spec % size,
         rule_types_allowed=DEFAULT_RULES_AND_POSITION_TRY,
-        servo_restyle_damage="reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
     ${helpers.predefined_type(
@@ -238,7 +239,7 @@ ${helpers.predefined_type(
         allow_quirks="No" if logical else "Yes",
         spec=spec % size,
         rule_types_allowed=DEFAULT_RULES_AND_POSITION_TRY,
-        servo_restyle_damage="reflow",
+        servo_restyle_damage="rebuild_box",
         affects="layout",
     )}
 % endfor
@@ -313,7 +314,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleBoxSizing",
     custom_consts={ "content-box": "Content", "border-box": "Border" },
     animation_type="discrete",
-    servo_restyle_damage = "reflow",
+    servo_restyle_damage = "rebuild_box",
     affects="layout",
 )}
 
@@ -415,7 +416,7 @@ ${helpers.predefined_type(
     aliases="grid-column-gap",
     servo_pref="layout.flexbox.enabled",
     spec="https://drafts.csswg.org/css-align-3/#propdef-column-gap",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -428,7 +429,7 @@ ${helpers.predefined_type(
     aliases="grid-row-gap",
     servo_pref="layout.flexbox.enabled",
     spec="https://drafts.csswg.org/css-align-3/#propdef-row-gap",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -438,7 +439,7 @@ ${helpers.predefined_type(
     "computed::AspectRatio::auto()",
     engines="gecko servo",
     spec="https://drafts.csswg.org/css-sizing-4/#aspect-ratio",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/svg.mako.rs
+++ b/style/properties/longhands/svg.mako.rs
@@ -83,6 +83,7 @@ ${helpers.predefined_type(
     extra_prefixes="webkit",
     spec="https://drafts.fxtf.org/css-masking-1/#propdef-clip-path",
     affects="paint",
+    servo_restyle_damage="repaint",
 )}
 
 ${helpers.single_keyword(

--- a/style/properties/longhands/table.mako.rs
+++ b/style/properties/longhands/table.mako.rs
@@ -12,7 +12,7 @@ ${helpers.single_keyword(
     animation_type="discrete",
     gecko_enum_prefix="StyleTableLayout",
     spec="https://drafts.csswg.org/css-tables/#propdef-table-layout",
-    servo_restyle_damage="reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 

--- a/style/properties/longhands/text.mako.rs
+++ b/style/properties/longhands/text.mako.rs
@@ -13,7 +13,7 @@ ${helpers.predefined_type(
     animation_type="discrete",
     boxed=True,
     spec="https://drafts.csswg.org/css-ui/#propdef-text-overflow",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="paint",
 )}
 
@@ -24,7 +24,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleUnicodeBidi",
     animation_type="none",
     spec="https://drafts.csswg.org/css-writing-modes/#propdef-unicode-bidi",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="layout",
 )}
 
@@ -36,7 +36,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::TextDecorationLine::none()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-line",
-    servo_restyle_damage="rebuild_and_reflow",
+    servo_restyle_damage="rebuild_box",
     affects="overflow",
 )}
 

--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -2946,7 +2946,7 @@ const_assert!(std::mem::size_of::<longhands::${longhand.ident}::SpecifiedValue>(
 % endfor
 
 % if engine == "servo":
-% for effect_name in ["repaint", "reflow_out_of_flow", "reflow", "rebuild_and_reflow_inline", "rebuild_and_reflow"]:
+% for effect_name in ["repaint", "rebuild_stacking_context", "rebuild_box"]:
     macro_rules! restyle_damage_${effect_name} {
         ($old: ident, $new: ident, $damage: ident, [ $($effect:expr),* ]) => ({
             restyle_damage_${effect_name}!($old, $new, $damage, [$($effect),*], false)


### PR DESCRIPTION
This restyle damage is used in cases where we need to reconstruct the stacking contexts, because a style change has caused a box to establish or stop establishing a stacking context, but it's unnecessary to rebuild the box tree.

Additionally, `ServoRestyleDamage::REBUILD` is renamed to `REBUILD_BOX`, and old `servo_restyle_damage` values are removed in favor of it.

Servo PR: https://github.com/servo/servo/pull/37088