### PR TITLE
Have `filter` changes conditionally trigger only repaint damage

### DIFF
--- a/style/properties/longhands/box.mako.rs
+++ b/style/properties/longhands/box.mako.rs
@@ -436,6 +436,7 @@ ${helpers.single_keyword(
     spec="https://drafts.csswg.org/css-transforms/#backface-visibility-property",
     extra_prefixes=transform_extra_prefixes,
     animation_type="discrete",
+    servo_restyle_damage="repaint",
     affects="paint",
 )}
 

--- a/style/properties/longhands/effects.mako.rs
+++ b/style/properties/longhands/effects.mako.rs
@@ -53,6 +53,7 @@ ${helpers.predefined_type(
     extra_prefixes="webkit",
     spec="https://drafts.fxtf.org/filters/#propdef-filter",
     affects="overflow",
+    servo_restyle_damage="repaint",
 )}
 
 ${helpers.predefined_type(

--- a/style/servo/restyle_damage.rs
+++ b/style/servo/restyle_damage.rs
@@ -119,7 +119,8 @@ fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDam
         new,
         damage,
         [ServoRestyleDamage::REBUILD_BOX],
-        old.get_box().original_display != new.get_box().original_display
+        old.get_box().original_display != new.get_box().original_display ||
+            old.get_effects().filter.0.is_empty() != new.get_effects().filter.0.is_empty()
     ) || restyle_damage_rebuild_stacking_context!(
         old,
         new,


### PR DESCRIPTION
In many cases, changes to filters do not require rebuilding the box tree and laying out again. This change uses REPAINT restyle damage in these cases, except when changing between no filter and a filter. In those cases we need to rebuild the box tree.