### PR TITLE
Eliminate `unicode-bidi` dependency

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -100,7 +100,6 @@ to_shmem = { version = "0.2", path = "../to_shmem" }
 to_shmem_derive = { version = "0.1", path = "../to_shmem_derive" }
 thin-vec = "0.2.1"
 uluru = "3.0"
-unicode-bidi = { version = "0.3", default-features = false }
 void = "1.0.2"
 url = { version = "2.5", optional = true, features = ["serde"] }
 

--- a/style/logical_geometry.rs
+++ b/style/logical_geometry.rs
@@ -10,7 +10,6 @@ use euclid::num::Zero;
 use std::cmp::{max, min};
 use std::fmt::{self, Debug, Error, Formatter};
 use std::ops::{Add, Sub};
-use unicode_bidi as bidi;
 
 pub enum BlockFlowDirection {
     TopToBottom,
@@ -311,18 +310,6 @@ impl WritingMode {
             InlineBaseDirection::RightToLeft
         } else {
             InlineBaseDirection::LeftToRight
-        }
-    }
-
-    #[inline]
-    /// The default bidirectional embedding level for this writing mode.
-    ///
-    /// Returns bidi level 0 if the mode is LTR, or 1 otherwise.
-    pub fn to_bidi_level(&self) -> bidi::Level {
-        if self.is_bidi_ltr() {
-            bidi::Level::ltr()
-        } else {
-            bidi::Level::rtl()
         }
     }
 


### PR DESCRIPTION
The `unicode-bidi` crate is only used for it's `Level` type which is just a newtype of `u8`. This PR deletes that function and removes the dependency. Gecko does not appear to use this function.

Corresponding Servo PR (adds the function to Servo): https://github.com/servo/servo/pull/37343