### PR TITLE
Use `Cell` instead of `RefCell` for storing `ThreadState`

### DIFF
--- a/style/thread_state.rs
+++ b/style/thread_state.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-//! Supports dynamic assertions in about what sort of thread is running and
+//! Supports dynamic assertions about what sort of thread is running and
 //! what state it's in.
 
 #![deny(missing_docs)]
@@ -44,7 +44,7 @@ impl ThreadState {
     }
 }
 
-thread_local!(static STATE: Cell<Option<ThreadState>> = Cell::new(None));
+thread_local!(static STATE: Cell<Option<ThreadState>> = const { Cell::new(None) });
 
 /// Initializes the current thread state.
 pub fn initialize(initialize_to: ThreadState) {

--- a/style/thread_state.rs
+++ b/style/thread_state.rs
@@ -27,25 +27,21 @@ bitflags! {
     }
 }
 
-macro_rules! thread_types ( ( $( $fun:ident = $flag:path ; )* ) => (
-    impl ThreadState {
-        /// Whether the current thread is a worker thread.
-        pub fn is_worker(self) -> bool {
-            self.contains(ThreadState::IN_WORKER)
-        }
-
-        $(
-            #[allow(missing_docs)]
-            pub fn $fun(self) -> bool {
-                self.contains($flag)
-            }
-        )*
+impl ThreadState {
+    /// Whether the current thread is a worker thread.
+    pub fn is_worker(self) -> bool {
+        self.contains(ThreadState::IN_WORKER)
     }
-));
 
-thread_types! {
-    is_script = ThreadState::SCRIPT;
-    is_layout = ThreadState::LAYOUT;
+    /// Whether the current thread is a script thread.
+    pub fn is_script(self) -> bool {
+        self.contains(ThreadState::SCRIPT)
+    }
+
+    /// Whether the current thread is a layout thread.
+    pub fn is_layout(self) -> bool {
+        self.contains(ThreadState::LAYOUT)
+    }
 }
 
 thread_local!(static STATE: Cell<Option<ThreadState>> = Cell::new(None));


### PR DESCRIPTION
I profiled servo loading a local copy of https://html.spec.whatwg.org and saw around 15% of the time being spent in `style::thread_state::get()`. Most calls are inside assertions, so they likely go away in a production build, but that's still way too much time. Arguably we shouldn't assert on the thread state that much in the first place, especially given that layout and script are now in the same thread, but replacing the `RefCell` with a `Cell` already takes the time down to 10%.

Additionally, this change renames all one-letter variables for clarity and removes the `thread_types` macro because it is unnecessary (Removing it *decreases* the LoC!)

I wasn't sure whether I should submit the patch here or upstream, but gecko doesn't use the thread state so i figured this repo was the right place.