### PR TITLE
Correct some issues with the sync script

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -19,5 +19,5 @@ jobs:
           key: upstream
       - run: |
           ./sync.sh _filtered
-          git fetch -f --progress ./_filtered master:upstream
+          git fetch -f --progress ./_filtered main:upstream
           git push -fu --progress origin upstream

--- a/sync.sh
+++ b/sync.sh
@@ -30,7 +30,7 @@ fi
 
 step Cloning upstream if needed
 if ! [ -e upstream ]; then
-    git clone --bare --single-branch --progress https://github.com/mozilla-firefox/firefox.git upstream
+    git clone --bare --single-branch --branch main --progress https://github.com/mozilla-firefox/firefox.git upstream
 fi
 
 step Updating upstream


### PR DESCRIPTION
The `main` branch is used by the upstream Firefox repository, so use
that everywhere.

Signed-off-by: Martin Robinson <mrobinson@igalia.com>
