### PR TITLE
Define `::color-swatch` Pseudo Element of Input `type=color` 

### DIFF
--- a/style/rule_collector.rs
+++ b/style/rule_collector.rs
@@ -104,12 +104,6 @@ where
 
         let matches_user_and_content_rules = rule_hash_target.matches_user_and_content_rules();
 
-        // Gecko definitely has pseudo-elements with style attributes, like
-        // ::-moz-color-swatch.
-        debug_assert!(
-            cfg!(feature = "gecko") || style_attribute.is_none() || pseudo_element.is_none(),
-            "Style attributes do not apply to pseudo-elements"
-        );
         debug_assert!(pseudo_element.map_or(true, |p| !p.is_precomputed()));
 
         Self {

--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -61,10 +61,15 @@ pub enum PseudoElement {
     ServoAnonymousTableRow,
     ServoTableGrid,
     ServoTableWrapper,
+
+    // Implemented pseudos. These pseudo elements are representing the
+    // elements within an UA shadow DOM, and matching the elements with
+    // their appropriate styles.
+    ColorSwatch,
 }
 
 /// The count of all pseudo-elements.
-pub const PSEUDO_COUNT: usize = PseudoElement::ServoTableWrapper as usize + 1;
+pub const PSEUDO_COUNT: usize = PseudoElement::ColorSwatch as usize + 1;
 
 impl ToCss for PseudoElement {
     fn to_css<W>(&self, dest: &mut W) -> fmt::Result
@@ -86,6 +91,7 @@ impl ToCss for PseudoElement {
             ServoAnonymousTableRow => "::-servo-anonymous-table-row",
             ServoTableGrid => "::-servo-table-grid",
             ServoTableWrapper => "::-servo-table-wrapper",
+            ColorSwatch => "::color-swatch",
         })
     }
 }
@@ -173,10 +179,11 @@ impl PseudoElement {
         false
     }
 
-    /// Whether this pseudo-element is the ::-moz-color-swatch pseudo.
+    /// Whether this pseudo-element is the pseudo element representing
+    /// the color swatch inside an `<input>` element.
     #[inline]
     pub fn is_color_swatch(&self) -> bool {
-        false
+        *self == PseudoElement::ColorSwatch
     }
 
     /// Whether this pseudo-element is eagerly-cascaded.
@@ -224,7 +231,8 @@ impl PseudoElement {
             },
             PseudoElement::Backdrop |
             PseudoElement::DetailsSummary |
-            PseudoElement::Marker  => PseudoElementCascadeType::Lazy,
+            PseudoElement::Marker |
+            PseudoElement::ColorSwatch => PseudoElementCascadeType::Lazy,
             PseudoElement::DetailsContent |
             PseudoElement::ServoAnonymousBox |
             PseudoElement::ServoAnonymousTable |
@@ -645,6 +653,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                 }
                 ServoTableWrapper
             },
+            "color-swatch" => ColorSwatch,
             _ => return Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))
 
         };


### PR DESCRIPTION
Define `::color-swatch` pseudo element https://drafts.csswg.org/css-forms-1/#color-swatch-pseudo. It represents the element that display the chosen color value of Input `type=color`. Particularly, `::color-swatch` is a pseudo element with a concrete DOM element behind it, and it is defined as lazy pseudo element. 

Stylo's companion of https://github.com/servo/servo/pull/37427