### PR TITLE
Add support for the ::color-swatch pseudo-element

### DIFF
--- a/style/dom.rs
+++ b/style/dom.rs
@@ -669,8 +669,6 @@ pub trait TElement:
     ///
     /// Note that we still need to compute the pseudo-elements before-hand,
     /// given otherwise we don't know if we need to create an element or not.
-    ///
-    /// Servo doesn't have to deal with this.
     fn implemented_pseudo_element(&self) -> Option<PseudoElement> {
         None
     }

--- a/style/rule_collector.rs
+++ b/style/rule_collector.rs
@@ -104,12 +104,6 @@ where
 
         let matches_user_and_content_rules = rule_hash_target.matches_user_and_content_rules();
 
-        // Gecko definitely has pseudo-elements with style attributes, like
-        // ::-moz-color-swatch.
-        debug_assert!(
-            cfg!(feature = "gecko") || style_attribute.is_none() || pseudo_element.is_none(),
-            "Style attributes do not apply to pseudo-elements"
-        );
         debug_assert!(pseudo_element.map_or(true, |p| !p.is_precomputed()));
 
         Self {

--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -55,6 +55,13 @@ pub enum PseudoElement {
     DetailsSummary,
     DetailsContent,
     Marker,
+
+    // Implemented pseudos. These pseudo elements are representing the
+    // elements within an UA shadow DOM, and matching the elements with
+    // their appropriate styles.
+    ColorSwatch,
+
+    // Servo-specific pseudos
     ServoAnonymousBox,
     ServoAnonymousTable,
     ServoAnonymousTableCell,
@@ -80,6 +87,7 @@ impl ToCss for PseudoElement {
             DetailsSummary => "::-servo-details-summary",
             DetailsContent => "::-servo-details-content",
             Marker => "::marker",
+            ColorSwatch => "::color-swatch",
             ServoAnonymousBox => "::-servo-anonymous-box",
             ServoAnonymousTable => "::-servo-anonymous-table",
             ServoAnonymousTableCell => "::-servo-anonymous-table-cell",
@@ -173,10 +181,11 @@ impl PseudoElement {
         false
     }
 
-    /// Whether this pseudo-element is the ::-moz-color-swatch pseudo.
+    /// Whether this pseudo-element is representing the color swatch
+    /// inside an `<input>` element.
     #[inline]
     pub fn is_color_swatch(&self) -> bool {
-        false
+        *self == PseudoElement::ColorSwatch
     }
 
     /// Whether this pseudo-element is eagerly-cascaded.
@@ -223,8 +232,9 @@ impl PseudoElement {
                 PseudoElementCascadeType::Eager
             },
             PseudoElement::Backdrop |
+            PseudoElement::ColorSwatch |
             PseudoElement::DetailsSummary |
-            PseudoElement::Marker  => PseudoElementCascadeType::Lazy,
+            PseudoElement::Marker => PseudoElementCascadeType::Lazy,
             PseudoElement::DetailsContent |
             PseudoElement::ServoAnonymousBox |
             PseudoElement::ServoAnonymousTable |
@@ -609,6 +619,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
                 }
                 DetailsContent
             },
+            "color-swatch" => ColorSwatch,
             "-servo-anonymous-box" => {
                 if !self.in_user_agent_stylesheet() {
                     return Err(location.new_custom_error(SelectorParseErrorKind::UnexpectedIdent(name.clone())))


### PR DESCRIPTION
Define `::color-swatch` pseudo element https://drafts.csswg.org/css-forms-1/#color-swatch-pseudo. It represents the element that display the chosen color value of Input `type=color`. Particularly, `::color-swatch` is a pseudo element with a concrete DOM element behind it, and it is defined as lazy pseudo element. 

The pseudo element would be public because of no additional requirement specified (e.g. property restriction) and the element is defined in Servo.

Stylo's companion of https://github.com/servo/servo/pull/37427

This is a reopened PR of https://github.com/servo/stylo/pull/208 due to the new upstream.
