### PR TITLE
Release `v0.5.1`

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stylo"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Servo Project Developers"]
 license = "MPL-2.0"
 repository = "https://github.com/servo/stylo"


### PR DESCRIPTION
I'm not sure what the best way to do this is as we don't really have a defined process, but I wanted to put out a patch release that includes https://github.com/servo/stylo/pull/215 as 0.5 is broken in a lot places without that (and it's easy enough to do as it's only the top-level `stylo` crate that's affected.

I think `main` has breaking changes so I have:

- Created a new `v0.5.x` branch from the `v0.5.0` tag
- Cherry-picked https://github.com/servo/stylo/pull/215
- Created this PR against that branch with a patch version bump for only the `stylo` crate

Feel free to rename the branch or whatever if you'd like to do things differently.