### PR TITLE
Drop obsolete `layout.css.transition-behavior.enabled` flag

### DIFF
--- a/stylo_static_prefs/src/lib.rs
+++ b/stylo_static_prefs/src/lib.rs
@@ -33,9 +33,6 @@ macro_rules! pref {
     ("layout.css.stretch-size-keyword.enabled") => {
         true
     };
-    ("layout.css.transition-behavior.enabled") => {
-        true
-    };
     ("layout.css.marker.restricted") => {
         true
     };


### PR DESCRIPTION
There is no point in setting this flag to true when it's no longer doing anything, `transition-behavior` is now enabled unconditionally.