### PR TITLE
Optimise style comparison when computing damage

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1788,6 +1788,34 @@ impl ComputedValues {
       self.custom_properties() == other.custom_properties()
     }
 
+    /// Runs cheap ptr_eq checks to determine whether the styles may differ:
+    ///
+    /// - If this function returns false, then all styles are definitely equal
+    /// - If this function returns true, then styles may or may not be equal
+    ///   and further checks (e.g. full deep equals) is necessary.
+    ///
+    /// Checks by:
+    ///   - Doing a pointer comparison on the top-level pointer. If the pointers
+    ///     point to the exact same struct then they must be equal.
+    ///   - Doing a pointer comparison on each "style struct"
+    ///   - A regular Eq compare on writing_mode and effective_zoom
+    pub fn styles_may_differ(&self, other: &Self) -> bool  {
+        use servo_arc::Arc;
+
+        if std::ptr::eq(self, other) {
+            return false;
+        }
+
+        let all_ptrs_eq = 
+        % for style_struct in data.active_style_structs():
+            Arc::ptr_eq(&self.${style_struct.ident}, &other.${style_struct.ident}) &&
+        % endfor
+        self.writing_mode == other.writing_mode &&
+        self.effective_zoom == other.effective_zoom;
+
+        !all_ptrs_eq
+    }
+
 % for prop in data.longhands:
 % if not prop.logical:
     /// Gets the computed value of a given property.

--- a/style/servo/restyle_damage.rs
+++ b/style/servo/restyle_damage.rs
@@ -59,8 +59,9 @@ impl ServoRestyleDamage {
         old: &ComputedValues,
         new: &ComputedValues,
     ) -> StyleDifference {
-        let mut damage = compute_damage(old, new);
-        if damage.is_empty() {
+        let styles_may_differ = old.styles_may_differ(&new);
+        let mut damage = compute_damage(old, new, styles_may_differ);
+        if damage.is_empty() && !styles_may_differ {
             return StyleDifference {
                 damage,
                 change: StyleChange::Unchanged,
@@ -144,22 +145,30 @@ fn augmented_restyle_damage_rebuild_stacking_context(
     restyle_damage_rebuild_stacking_context(old, new)
         || old.guarantees_stacking_context() != new.guarantees_stacking_context()
 }
-fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDamage {
+
+fn compute_damage(
+    old: &ComputedValues,
+    new: &ComputedValues,
+    styles_may_differ: bool,
+) -> ServoRestyleDamage {
     let mut damage = ServoRestyleDamage::empty();
 
     // Damage flags higher up the if-else chain imply damage flags lower down the if-else chain,
     // so we can skip the diffing process for later flags if an earlier flag is true
-    if augmented_restyle_damage_rebuild_box(old, new) {
-        damage.insert(ServoRestyleDamage::RELAYOUT)
-    } else if restyle_damage_recalculate_overflow(old, new) {
-        damage.insert(ServoRestyleDamage::RECALCULATE_OVERFLOW)
-    } else if augmented_restyle_damage_rebuild_stacking_context(old, new) {
-        damage.insert(ServoRestyleDamage::REBUILD_STACKING_CONTEXT);
-    } else if restyle_damage_repaint(old, new) {
-        damage.insert(ServoRestyleDamage::REPAINT);
+    if styles_may_differ {
+        if augmented_restyle_damage_rebuild_box(old, new) {
+            damage.insert(ServoRestyleDamage::RELAYOUT)
+        } else if restyle_damage_recalculate_overflow(old, new) {
+            damage.insert(ServoRestyleDamage::RECALCULATE_OVERFLOW)
+        } else if augmented_restyle_damage_rebuild_stacking_context(old, new) {
+            damage.insert(ServoRestyleDamage::REBUILD_STACKING_CONTEXT);
+        } else if restyle_damage_repaint(old, new) {
+            damage.insert(ServoRestyleDamage::REPAINT);
+        }
     }
+
     // Paint worklets may depend on custom properties, so if they have changed we should repaint.
-    else if !old.custom_properties_equal(new) {
+    if !damage.is_empty() && !old.custom_properties_equal(new) {
         damage.insert(ServoRestyleDamage::REPAINT);
     }
 


### PR DESCRIPTION
Fixes https://github.com/servo/stylo/issues/226

This compares the pointers of every single style_struct, which may not be necessary. We may instead wish to inject style_struct pointer comparison into each generated comparison. In either case it probably makes sense to compare the top-level pointer to the entire `ComputedValues`, and bail early if they are equal. That captures the (common) case where the styles for a node are entirely unchanged.