### PR TITLE
Replace `fxhash`, which is unmaintained, with `rustc-hash`.

### DIFF
--- a/selectors/Cargo.toml
+++ b/selectors/Cargo.toml
@@ -23,7 +23,7 @@ to_shmem = ["dep:to_shmem", "dep:to_shmem_derive"]
 bitflags = "2"
 cssparser = "0.35"
 derive_more = { version = "2", features = ["add", "add_assign"] }
-fxhash = "0.2"
+rustc-hash = "2.1.1"
 log = "0.4"
 phf = "0.11"
 precomputed-hash = "0.1"

--- a/selectors/bloom.rs
+++ b/selectors/bloom.rs
@@ -283,7 +283,7 @@ fn hash2(hash: u32) -> u32 {
 
 #[test]
 fn create_and_insert_some_stuff() {
-    use fxhash::FxHasher;
+    use rustc_hash::FxHasher;
     use std::hash::{Hash, Hasher};
     use std::mem::transmute;
 

--- a/selectors/nth_index_cache.rs
+++ b/selectors/nth_index_cache.rs
@@ -5,7 +5,7 @@
 use std::hash::Hash;
 
 use crate::{parser::Selector, tree::OpaqueElement, SelectorImpl};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 /// A cache to speed up matching of nth-index-like selectors.
 ///

--- a/selectors/relative_selector/cache.rs
+++ b/selectors/relative_selector/cache.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 /// Relative selector cache. This is useful for following cases.
 /// First case is non-subject relative selector: Imagine `.anchor:has(<..>) ~ .foo`, with DOM
 /// `.anchor + .foo + .. + .foo`. Each match on `.foo` triggers `:has()` traversal that

--- a/selectors/relative_selector/filter.rs
+++ b/selectors/relative_selector/filter.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 /// Bloom filter for relative selectors.
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 use crate::bloom::BloomFilter;
 use crate::context::QuirksMode;

--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -64,7 +64,7 @@ dom = { version = "0.7", path = "../stylo_dom", package = "stylo_dom" }
 new_debug_unreachable = "1.0"
 encoding_rs = {version = "0.8", optional = true}
 euclid = "0.22"
-fxhash = "0.2"
+rustc-hash = "2.1.1"
 icu_segmenter = { version = "1.5", default-features = false, features = ["auto", "compiled_data"] }
 indexmap = {version = "2", features = ["std"]}
 itertools = "0.14"

--- a/style/context.rs
+++ b/style/context.rs
@@ -29,7 +29,7 @@ use app_units::Au;
 use euclid::default::Size2D;
 use euclid::Scale;
 #[cfg(feature = "servo")]
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use selectors::context::SelectorCaches;
 #[cfg(feature = "gecko")]
 use servo_arc::Arc;

--- a/style/gecko/wrapper.rs
+++ b/style/gecko/wrapper.rs
@@ -71,7 +71,7 @@ use app_units::Au;
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use dom::{DocumentState, ElementState};
 use euclid::default::Size2D;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::bloom::{BloomFilter, BLOOM_HASH_MASK};
 use selectors::matching::VisitedHandlingMode;

--- a/style/invalidation/element/relative_selector.rs
+++ b/style/invalidation/element/relative_selector.rs
@@ -27,7 +27,7 @@ use crate::invalidation::element::state_and_attributes::{
 use crate::selector_parser::SnapshotMap as ServoElementSnapshotTable;
 use crate::stylist::{CascadeData, Stylist};
 use dom::ElementState;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use selectors::matching::{
     matches_selector, ElementSelectorFlags, IncludeStartingStyle, MatchingContext,
     MatchingForInvalidation, MatchingMode, NeedsSelectorFlags, QuirksMode, SelectorCaches,

--- a/style/invalidation/media_queries.rs
+++ b/style/invalidation/media_queries.rs
@@ -9,7 +9,7 @@ use crate::media_queries::Device;
 use crate::shared_lock::SharedRwLockReadGuard;
 use crate::stylesheets::{DocumentRule, ImportRule, MediaRule};
 use crate::stylesheets::{NestedRuleIterationCondition, StylesheetContents, SupportsRule};
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 
 /// A key for a given media query result.
 ///

--- a/style/properties/cascade.rs
+++ b/style/properties/cascade.rs
@@ -30,7 +30,7 @@ use crate::stylist::Stylist;
 #[cfg(feature = "gecko")]
 use crate::values::specified::length::FontBaseSize;
 use crate::values::{computed, specified};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use servo_arc::Arc;
 use smallvec::SmallVec;
 use std::borrow::Cow;

--- a/style/properties/helpers/animated_properties.mako.rs
+++ b/style/properties/helpers/animated_properties.mako.rs
@@ -23,7 +23,7 @@ use crate::properties::{
 };
 use std::ptr;
 use std::mem;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use super::ComputedValues;
 use crate::properties::OwnedPropertyDeclarationId;
 use crate::values::animated::{Animate, Procedure, ToAnimatedValue, ToAnimatedZero};

--- a/style/properties/mod.rs
+++ b/style/properties/mod.rs
@@ -31,7 +31,7 @@ use crate::stylist::Stylist;
 use crate::values::{computed, serialize_atom_name};
 use arrayvec::{ArrayVec, Drain as ArrayVecDrain};
 use cssparser::{Parser, ParserInput};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use servo_arc::Arc;
 use std::{
     borrow::Cow,

--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1396,7 +1396,7 @@ pub use super::gecko::style_structs;
 /// The module where all the style structs are defined.
 #[cfg(feature = "servo")]
 pub mod style_structs {
-    use fxhash::FxHasher;
+    use rustc_hash::FxHasher;
     use super::longhands;
     use std::hash::{Hash, Hasher};
     use crate::values::specified::color::ColorSchemeFlags;

--- a/style/rule_cache.rs
+++ b/style/rule_cache.rs
@@ -12,7 +12,7 @@ use crate::selector_parser::PseudoElement;
 use crate::shared_lock::StylesheetGuards;
 use crate::values::computed::{NonNegativeLength, Zoom};
 use crate::values::specified::color::ColorSchemeFlags;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use servo_arc::Arc;
 use smallvec::SmallVec;
 

--- a/style/rule_tree/core.rs
+++ b/style/rule_tree/core.rs
@@ -128,7 +128,7 @@ impl RuleTree {
             return;
         }
 
-        let mut children_count = fxhash::FxHashMap::default();
+        let mut children_count = rustc_hash::FxHashMap::default();
 
         let mut stack = SmallVec::<[_; 32]>::new();
         stack.push(self.root.clone());

--- a/style/rule_tree/map.rs
+++ b/style/rule_tree/map.rs
@@ -4,7 +4,7 @@
 
 #![forbid(unsafe_code)]
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOfOps};
 use std::collections::hash_map;
 use std::hash::Hash;

--- a/style/servo/animation.rs
+++ b/style/servo/animation.rs
@@ -29,7 +29,7 @@ use crate::values::computed::TimingFunction;
 use crate::values::generics::easing::BeforeFlag;
 use crate::values::specified::TransitionBehavior;
 use crate::Atom;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use parking_lot::RwLock;
 use servo_arc::Arc;
 use std::fmt;

--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -19,7 +19,7 @@ use crate::values::{AtomIdent, AtomString};
 use crate::{Atom, CaseSensitivityExt, LocalName, Namespace, Prefix};
 use cssparser::{serialize_identifier, CowRcStr, Parser as CssParser, SourceLocation, ToCss};
 use dom::{DocumentState, ElementState};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use selectors::attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint};
 use selectors::parser::SelectorParseErrorKind;
 use selectors::visitor::SelectorVisitor;

--- a/style/stylesheets/stylesheet.rs
+++ b/style/stylesheets/stylesheet.rs
@@ -16,7 +16,7 @@ use crate::stylesheets::{CssRule, CssRules, Origin, UrlExtraData};
 use crate::use_counters::UseCounters;
 use crate::{Namespace, Prefix};
 use cssparser::{Parser, ParserInput, StyleSheetParser};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 #[cfg(feature = "gecko")]
 use malloc_size_of::{MallocSizeOfOps, MallocUnconditionalShallowSizeOf};
 use parking_lot::RwLock;

--- a/style/stylist.rs
+++ b/style/stylist.rs
@@ -58,7 +58,7 @@ use crate::values::{computed, AtomIdent};
 use crate::AllocErr;
 use crate::{Atom, LocalName, Namespace, ShrinkIfNeeded, WeakAtom};
 use dom::{DocumentState, ElementState};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 #[cfg(feature = "gecko")]
 use malloc_size_of::MallocUnconditionalShallowSizeOf;
 use malloc_size_of::{MallocShallowSizeOf, MallocSizeOf, MallocSizeOfOps};


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2025-0057.html.