### PR TITLE
Use a range specifier for the `icu4x` dependency

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -65,7 +65,7 @@ new_debug_unreachable = "1.0"
 encoding_rs = {version = "0.8", optional = true}
 euclid = "0.22"
 fxhash = "0.2"
-icu_segmenter = { version = "1.5", default-features = false, features = ["auto", "compiled_data"] }
+icu_segmenter = { version = ">= 1.5, <= 2.*", default-features = false, features = ["auto", "compiled_data"] }
 indexmap = {version = "2", features = ["std"]}
 itertools = "0.14"
 itoa = "1.0"


### PR DESCRIPTION
This allows Stylo to be compiled with *either* v1.5.x or v2.x of `icu4x` (luckily Stylo doesn't actually depend on any APIs with breaking changes). Which means that Servo can continue to compile Stylo with `icu4x` 1.5 until such time as it is [ready to upgrade](https://github.com/servo/servo/pull/37823) while other consumers of Stylo can compile it with icu4x 2.0 if they wish to.