### PR TITLE
Add support for `-webkit-fill-available` sizing keyword

### DIFF
--- a/style/values/generics/length.rs
+++ b/style/values/generics/length.rs
@@ -164,7 +164,6 @@ pub enum GenericSize<LengthPercent> {
     #[cfg(feature = "gecko")]
     #[animation(error)]
     MozAvailable,
-    #[cfg(feature = "gecko")]
     #[animation(error)]
     WebkitFillAvailable,
     #[animation(error)]
@@ -182,14 +181,12 @@ where
 {
     fn collect_completion_keywords(f: style_traits::KeywordsCollectFn) {
         LengthPercent::collect_completion_keywords(f);
-        f(&["auto", "stretch", "fit-content"]);
+        f(&["auto", "stretch", "fit-content", "max-content", "min-content"]);
         if cfg!(feature = "gecko") {
-            f(&[
-                "max-content",
-                "min-content",
-                "-moz-available",
-                "-webkit-fill-available",
-            ]);
+            f(&["-moz-available"]);
+        }
+        if static_prefs::pref!("layout.css.webkit-fill-available.enabled") {
+            f(&["-webkit-fill-available"]);
         }
         if static_prefs::pref!("layout.css.anchor-positioning.enabled") {
             f(&["anchor-size"]);
@@ -242,7 +239,6 @@ pub enum GenericMaxSize<LengthPercent> {
     #[cfg(feature = "gecko")]
     #[animation(error)]
     MozAvailable,
-    #[cfg(feature = "gecko")]
     #[animation(error)]
     WebkitFillAvailable,
     #[animation(error)]
@@ -260,14 +256,12 @@ where
 {
     fn collect_completion_keywords(f: style_traits::KeywordsCollectFn) {
         LP::collect_completion_keywords(f);
-        f(&["none", "stretch", "fit-content"]);
+        f(&["none", "stretch", "fit-content", "max-content", "min-content"]);
         if cfg!(feature = "gecko") {
-            f(&[
-                "max-content",
-                "min-content",
-                "-moz-available",
-                "-webkit-fill-available",
-            ]);
+            f(&["-moz-available"]);
+        }
+        if static_prefs::pref!("layout.css.webkit-fill-available.enabled") {
+            f(&["-webkit-fill-available"]);
         }
         if static_prefs::pref!("layout.css.anchor-positioning.enabled") {
             f(&["anchor-size"]);

--- a/style/values/specified/length.rs
+++ b/style/values/specified/length.rs
@@ -2056,7 +2056,6 @@ macro_rules! parse_size_non_length {
                 "fit-content" | "-moz-fit-content" => $size::FitContent,
                 #[cfg(feature = "gecko")]
                 "-moz-available" => $size::MozAvailable,
-                #[cfg(feature = "gecko")]
                 "-webkit-fill-available" if is_webkit_fill_available_keyword_enabled() => $size::WebkitFillAvailable,
                 "stretch" if is_stretch_enabled() => $size::Stretch,
                 $auto_or_none => $size::$auto_or_none_ident,
@@ -2068,7 +2067,6 @@ macro_rules! parse_size_non_length {
     }};
 }
 
-#[cfg(feature = "gecko")]
 fn is_webkit_fill_available_keyword_enabled() -> bool {
     static_prefs::pref!("layout.css.webkit-fill-available.enabled")
 }

--- a/stylo_static_prefs/src/lib.rs
+++ b/stylo_static_prefs/src/lib.rs
@@ -36,6 +36,9 @@ macro_rules! pref {
     ("layout.css.marker.restricted") => {
         true
     };
+    ("layout.css.webkit-fill-available.enabled") => {
+        true
+    };
     ($string:literal) => {
         false
     };


### PR DESCRIPTION
This keyword is de-facto required for web compatibility, Firefox is also enabling it (https://bugzil.la/1988938).

Servo will just alias it to `stretch`.

Servo PR: https://github.com/servo/servo/pull/39492