### PR TITLE
Make servo feature default for `stylo_traits`

### DIFF
--- a/style_traits/Cargo.toml
+++ b/style_traits/Cargo.toml
@@ -13,6 +13,7 @@ name = "style_traits"
 path = "lib.rs"
 
 [features]
+default = ["servo"]
 servo = ["stylo_atoms", "cssparser/serde", "url", "euclid/serde"]
 gecko = []
 


### PR DESCRIPTION
We are already doing this (and maintaining the patch) for the `stylo` crate. This wasn't previously necessary for `stylo_traits`, but that crate now also requires one of (servo, gecko) in order to compile.