### PR TITLE
Refactor imported stylesheets for Servo

### DIFF
--- a/style/servo/encoding_support.rs
+++ b/style/servo/encoding_support.rs
@@ -78,26 +78,4 @@ impl Stylesheet {
             AllowImportRules::Yes,
         )
     }
-
-    /// Updates an empty stylesheet with a set of bytes that reached over the
-    /// network.
-    pub fn update_from_bytes(
-        existing: &Stylesheet,
-        bytes: &[u8],
-        protocol_encoding_label: Option<&str>,
-        environment_encoding: Option<&'static encoding_rs::Encoding>,
-        url_data: UrlExtraData,
-        stylesheet_loader: Option<&dyn StylesheetLoader>,
-        error_reporter: Option<&dyn ParseErrorReporter>,
-    ) {
-        let string = decode_stylesheet_bytes(bytes, protocol_encoding_label, environment_encoding);
-        Self::update_from_str(
-            existing,
-            &string,
-            url_data,
-            stylesheet_loader,
-            error_reporter,
-            AllowImportRules::Yes,
-        )
-    }
 }

--- a/style/stylesheets/import_rule.rs
+++ b/style/stylesheets/import_rule.rs
@@ -19,12 +19,16 @@ use std::fmt::{self, Write};
 use style_traits::{CssStringWriter, CssWriter, ToCss};
 use to_shmem::{SharedMemoryBuilder, ToShmem};
 
-/// A sheet that is held from an import rule.
 #[cfg(feature = "gecko")]
+type StyleSheet = crate::gecko::data::GeckoStyleSheet;
+#[cfg(feature = "servo")]
+type StyleSheet = ::servo_arc::Arc<crate::stylesheets::Stylesheet>;
+
+/// A sheet that is held from an import rule.
 #[derive(Debug)]
 pub enum ImportSheet {
     /// A bonafide stylesheet.
-    Sheet(crate::gecko::data::GeckoStyleSheet),
+    Sheet(StyleSheet),
 
     /// An @import created while parsing off-main-thread, whose Gecko sheet has
     /// yet to be created and attached.
@@ -34,10 +38,9 @@ pub enum ImportSheet {
     Refused,
 }
 
-#[cfg(feature = "gecko")]
 impl ImportSheet {
-    /// Creates a new ImportSheet from a GeckoStyleSheet.
-    pub fn new(sheet: crate::gecko::data::GeckoStyleSheet) -> Self {
+    /// Creates a new ImportSheet from a stylesheet.
+    pub fn new(sheet: StyleSheet) -> Self {
         ImportSheet::Sheet(sheet)
     }
 
@@ -51,10 +54,10 @@ impl ImportSheet {
         ImportSheet::Refused
     }
 
-    /// Returns a reference to the GeckoStyleSheet in this ImportSheet, if it
-    /// exists.
-    pub fn as_sheet(&self) -> Option<&crate::gecko::data::GeckoStyleSheet> {
+    /// Returns a reference to the stylesheet in this ImportSheet, if it exists.
+    pub fn as_sheet(&self) -> Option<&StyleSheet> {
         match *self {
+            #[cfg(feature = "gecko")]
             ImportSheet::Sheet(ref s) => {
                 debug_assert!(!s.hack_is_null());
                 if s.hack_is_null() {
@@ -62,6 +65,8 @@ impl ImportSheet {
                 }
                 Some(s)
             },
+            #[cfg(feature = "servo")]
+            ImportSheet::Sheet(ref s) => Some(s),
             ImportSheet::Refused | ImportSheet::Pending => None,
         }
     }
@@ -80,75 +85,21 @@ impl ImportSheet {
     }
 }
 
-#[cfg(feature = "gecko")]
 impl DeepCloneWithLock for ImportSheet {
     fn deep_clone_with_lock(&self, _lock: &SharedRwLock, _guard: &SharedRwLockReadGuard) -> Self {
-        use crate::gecko::data::GeckoStyleSheet;
-        use crate::gecko_bindings::bindings;
         match *self {
+            #[cfg(feature = "gecko")]
             ImportSheet::Sheet(ref s) => {
+                use crate::gecko_bindings::bindings;
                 let clone = unsafe { bindings::Gecko_StyleSheet_Clone(s.raw() as *const _) };
-                ImportSheet::Sheet(unsafe { GeckoStyleSheet::from_addrefed(clone) })
+                ImportSheet::Sheet(unsafe { StyleSheet::from_addrefed(clone) })
             },
-            ImportSheet::Pending => ImportSheet::Pending,
-            ImportSheet::Refused => ImportSheet::Refused,
-        }
-    }
-}
-
-/// A sheet that is held from an import rule.
-#[cfg(feature = "servo")]
-#[derive(Debug)]
-pub enum ImportSheet {
-    /// A bonafide stylesheet.
-    Sheet(::servo_arc::Arc<crate::stylesheets::Stylesheet>),
-
-    /// An @import created with a false <supports-condition>, so will never be fetched.
-    Refused,
-}
-
-#[cfg(feature = "servo")]
-impl ImportSheet {
-    /// Creates a new ImportSheet from a stylesheet.
-    pub fn new(sheet: ::servo_arc::Arc<crate::stylesheets::Stylesheet>) -> Self {
-        ImportSheet::Sheet(sheet)
-    }
-
-    /// Creates a refused ImportSheet for a load that will not happen.
-    pub fn new_refused() -> Self {
-        ImportSheet::Refused
-    }
-
-    /// Returns a reference to the stylesheet in this ImportSheet, if it exists.
-    pub fn as_sheet(&self) -> Option<&::servo_arc::Arc<crate::stylesheets::Stylesheet>> {
-        match *self {
-            ImportSheet::Sheet(ref s) => Some(s),
-            ImportSheet::Refused => None,
-        }
-    }
-
-    /// Returns the media list for this import rule.
-    pub fn media<'a>(&'a self, guard: &'a SharedRwLockReadGuard) -> Option<&'a MediaList> {
-        self.as_sheet().and_then(|s| s.media(guard))
-    }
-
-    /// Returns the rules for this import rule.
-    pub fn rules<'a>(&'a self, guard: &'a SharedRwLockReadGuard) -> &'a [CssRule] {
-        match self.as_sheet() {
-            Some(s) => s.rules(guard),
-            None => &[],
-        }
-    }
-}
-
-#[cfg(feature = "servo")]
-impl DeepCloneWithLock for ImportSheet {
-    fn deep_clone_with_lock(&self, _lock: &SharedRwLock, _guard: &SharedRwLockReadGuard) -> Self {
-        match *self {
+            #[cfg(feature = "servo")]
             ImportSheet::Sheet(ref s) => {
                 use servo_arc::Arc;
                 ImportSheet::Sheet(Arc::new((&**s).clone()))
             },
+            ImportSheet::Pending => ImportSheet::Pending,
             ImportSheet::Refused => ImportSheet::Refused,
         }
     }

--- a/style/stylesheets/loader.rs
+++ b/style/stylesheets/loader.rs
@@ -6,7 +6,6 @@
 //! for `@import` rules.
 
 use crate::media_queries::MediaList;
-use crate::parser::ParserContext;
 use crate::shared_lock::{Locked, SharedRwLock};
 use crate::stylesheets::import_rule::{ImportLayer, ImportRule, ImportSupportsCondition};
 use crate::values::CssUrl;
@@ -22,7 +21,6 @@ pub trait StylesheetLoader {
         &self,
         url: CssUrl,
         location: SourceLocation,
-        context: &ParserContext,
         lock: &SharedRwLock,
         media: Arc<Locked<MediaList>>,
         supports: Option<ImportSupportsCondition>,

--- a/style/stylesheets/rule_parser.rs
+++ b/style/stylesheets/rule_parser.rs
@@ -424,7 +424,6 @@ impl<'a, 'i> AtRuleParser<'i> for TopLevelRuleParser<'a, 'i> {
                 let import_rule = loader.request_stylesheet(
                     url,
                     start.source_location(),
-                    &self.context,
                     &self.shared_lock,
                     media,
                     supports,

--- a/style/stylesheets/stylesheet.rs
+++ b/style/stylesheets/stylesheet.rs
@@ -125,12 +125,13 @@ impl StylesheetContents {
     /// An empty namespace map should be fine, as it is only used for parsing,
     /// not serialization of existing selectors.  Since UA sheets are read only,
     /// we should never need the namespace map.
-    pub fn from_data(
+    pub fn from_shared_data(
         rules: Arc<Locked<CssRules>>,
         origin: Origin,
         url_data: UrlExtraData,
         quirks_mode: QuirksMode,
     ) -> Arc<Self> {
+        debug_assert!(rules.is_static());
         Arc::new(Self {
             rules,
             origin,
@@ -142,17 +143,6 @@ impl StylesheetContents {
             use_counters: UseCounters::default(),
             _forbid_construction: (),
         })
-    }
-
-    /// Same as above, but ensuring that the rules are static.
-    pub fn from_shared_data(
-        rules: Arc<Locked<CssRules>>,
-        origin: Origin,
-        url_data: UrlExtraData,
-        quirks_mode: QuirksMode,
-    ) -> Arc<Self> {
-        debug_assert!(rules.is_static());
-        Self::from_data(rules, origin, url_data, quirks_mode)
     }
 
     /// Returns a reference to the list of rules.


### PR DESCRIPTION
This patch does various things:
 - Unifies the definitions and implementations of `ImportSheet` among Gecko and Servo. In particular, Servo gains `ImportSheet::Pending`.
 - Removes unsound `StylesheetContents::from_data()`, which we were keeping as a diff from upstream.
 - Removes `Stylesheet::update_from_bytes()`. It was only used by Servo, which will no longer need it.

Servo PR: https://github.com/servo/servo/pull/39719