### PR TITLE
Mark some text decoration properties as overflow/repaint damage

### DIFF
--- a/style/properties/longhands/inherited_text.mako.rs
+++ b/style/properties/longhands/inherited_text.mako.rs
@@ -176,6 +176,7 @@ ${helpers.predefined_type(
     ignored_when_colors_disabled=True,
     simple_vector_bindings=True,
     spec="https://drafts.csswg.org/css-text-decor-3/#text-shadow-property",
+    servo_restyle_damage="repaint",
     affects="overflow",
 )}
 

--- a/style/properties/longhands/text.mako.rs
+++ b/style/properties/longhands/text.mako.rs
@@ -36,7 +36,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::TextDecorationLine::none()",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-line",
-    servo_restyle_damage="rebuild_box",
+    servo_restyle_damage="recalculate_overflow",
     affects="overflow",
 )}
 
@@ -47,6 +47,7 @@ ${helpers.single_keyword(
     gecko_enum_prefix="StyleTextDecorationStyle",
     animation_type="discrete",
     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-style",
+    servo_restyle_damage="recalculate_overflow",
     affects="overflow",
 )}
 
@@ -70,6 +71,7 @@ ${helpers.predefined_type(
     initial_specified_value="specified::Color::currentcolor()",
     ignored_when_colors_disabled=True,
     spec="https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-color",
+    servo_restyle_damage="recalculate_overflow",
     affects="paint",
 )}
 


### PR DESCRIPTION
Marks some text properties which I believe to affect paint/overflow only as such.

It is very common for `:hover` styles for inline spans (e.g. links) to update the `text-decoration` properties without updating any layout-affecting properties, and these updates can be triggered by events like "mouse move" and "scroll", so it is a nice optimisation to avoid layout / box construction for these updates.

Helps with https://github.com/servo/stylo/issues/235

Servo PR: https://github.com/servo/servo/pull/39769