### PR TITLE
Include generated `css-properties.html` as a rustdoc page

### DIFF
--- a/style/lib.rs
+++ b/style/lib.rs
@@ -17,6 +17,8 @@
 //!
 //! [recalc_style_at]: traversal/fn.recalc_style_at.html
 //!
+//! A list of supported style properties can be found as [docs::supported_properties]
+//!
 //! Major dependencies are the [cssparser][cssparser] and [selectors][selectors]
 //! crates.
 //!
@@ -133,6 +135,16 @@ pub mod use_counters;
 #[macro_use]
 #[allow(non_camel_case_types)]
 pub mod values;
+
+#[cfg(all(doc, feature = "servo"))]
+/// Documentation
+pub mod docs {
+    /// The CSS properties supported by the style system.
+    /// Generated from the `properties.mako.rs` template by `build.rs`
+    pub mod supported_properties {
+        #![doc = include_str!(concat!(env!("OUT_DIR"), "/css-properties.html"))]
+    }
+}
 
 #[cfg(feature = "gecko")]
 pub use crate::gecko_string_cache as string_cache;

--- a/style/properties/build.py
+++ b/style/properties/build.py
@@ -77,6 +77,7 @@ def main():
             write(doc_servo, "css-properties.html", as_html)
             write(doc_servo, "css-properties.json", as_json)
             write(OUT_DIR, "css-properties.json", as_json)
+            write(OUT_DIR, "css-properties.html", as_html)
     elif output == "geckolib":
         if len(sys.argv) < 4:
             abort(usage)


### PR DESCRIPTION
This module is only generated when running `cargo doc`. Should show up in docs.rs docs and be a record of the supported properties in each version of Stylo.