### PR TITLE
Bump web_atoms to 0.2.0

### DIFF
--- a/style/Cargo.toml
+++ b/style/Cargo.toml
@@ -73,7 +73,7 @@ lazy_static = "1"
 log = "0.4"
 malloc_size_of = { workspace = true }
 malloc_size_of_derive = "0.1"
-web_atoms = { version = "0.1.4", optional = true }
+web_atoms = { version = "0.2.0", optional = true }
 matches = "0.1"
 mime = { version = "0.3.13", optional = true }
 num_cpus = {version = "1.1.0"}


### PR DESCRIPTION
`web_atoms` 0.1.4 was semver breaking so it has been republished as 0.2.0