### PR TITLE
servo: Allow configuring style stack size

### DIFF
--- a/style/parallel.rs
+++ b/style/parallel.rs
@@ -34,8 +34,21 @@ pub const STYLE_THREAD_STACK_SIZE_KB: usize = 256;
 
 /// The minimum stack size for a thread in the styling pool, in kilobytes.
 /// Servo requires a bigger stack in debug builds.
+/// We allow configuring the size, since running with ASAN requires an even larger
+/// stack size.
 #[cfg(feature = "servo")]
-pub const STYLE_THREAD_STACK_SIZE_KB: usize = 512;
+pub const STYLE_THREAD_STACK_SIZE_KB: usize = const {
+    let default_stack_size = 512;
+    if let Some(user_def_size) = option_env!("SERVO_STYLE_THREAD_STACK_SIZE_KB") {
+        if let Ok(user_def_size) = usize::from_str_radix(user_def_size, 10) {
+            user_def_size
+        } else {
+            panic!("SERVO_STYLE_THREAD_STACK_SIZE_KB must be a valid integer")
+        }
+    } else {
+        default_stack_size
+    }
+};
 
 /// The stack margin. If we get this deep in the stack, we will skip recursive
 /// optimizations to ensure that there is sufficient room for non-recursive work.


### PR DESCRIPTION
When running Servo with ASAN we hit the stack limit. We can use compile-time parsing of environment variables, to allow the embedder to configure the style thread stack size.

Fixes https://github.com/servo/stylo/issues/223