### PR TITLE
Fix build failure on wasm32-unknown-emscripten due to overlapping cfg conditions

### DIFF
--- a/style/global_style_data.rs
+++ b/style/global_style_data.rs
@@ -11,7 +11,7 @@ use crate::parallel::STYLE_THREAD_STACK_SIZE_KB;
 use crate::shared_lock::SharedRwLock;
 use crate::thread_state;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 use std::os::unix::thread::{JoinHandleExt, RawPthread};
 #[cfg(windows)]
 use std::os::windows::{io::AsRawHandle, prelude::RawHandle};
@@ -19,7 +19,7 @@ use std::{io, thread};
 use thin_vec::ThinVec;
 
 /// Platform-specific handle to a thread.
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 pub type PlatformThreadHandle = RawPthread;
 /// Platform-specific handle to a thread.
 #[cfg(windows)]
@@ -142,7 +142,7 @@ impl StyleThreadPool {
         lazy_static::initialize(&STYLE_THREAD_POOL);
 
         for join_handle in STYLE_THREAD_JOIN_HANDLES.lock().iter() {
-            #[cfg(unix)]
+            #[cfg(all(unix, not(target_arch = "wasm32")))]
             let handle = join_handle.as_pthread_t();
             #[cfg(windows)]
             let handle = join_handle.as_raw_handle();


### PR DESCRIPTION
Fixes #272

## Problem
Building on `wasm32-unknown-emscripten` fails because Rust treats this target as `unix`, causing both `#[cfg(unix)]` and `#[cfg(all(target_arch = "wasm32", not(feature = "gecko")))]` to evaluate to true. This results in duplicate `PlatformThreadHandle` definitions and type mismatches.

## Solution
Exclude `wasm32` from the unix cfg conditions by changing:
- `#[cfg(unix)]` → `#[cfg(all(unix, not(target_arch = "wasm32")))]`

This ensures that on `wasm32-unknown-emscripten`, only the wasm32-specific path (using `DummyThreadHandle`) is active.

## Changes
- Updated import condition for `JoinHandleExt` and `RawPthread`
- Updated `PlatformThreadHandle` type alias condition
- Updated handle extraction in `get_thread_handles()`

## Testing
- ✅ Compiles successfully on default target (no regressions)
- ✅ Fixes build on `wasm32-unknown-emscripten`