### PR TITLE
Revert "Add stacking context damage when outline-width becomes non-zero (#274)"

### DIFF
--- a/style/servo/restyle_damage.rs
+++ b/style/servo/restyle_damage.rs
@@ -19,7 +19,6 @@ use crate::properties::{
 use crate::values::computed::basic_shape::ClipPath;
 use crate::values::computed::Perspective;
 use crate::values::generics::transform::{GenericRotate, GenericScale, GenericTranslate};
-use crate::Zero;
 use std::fmt;
 
 bitflags! {
@@ -149,7 +148,6 @@ fn augmented_restyle_damage_rebuild_stacking_context(
 ) -> bool {
     restyle_damage_rebuild_stacking_context(old, new)
         || old.guarantees_stacking_context() != new.guarantees_stacking_context()
-        || old.get_outline().outline_width.is_zero() != new.get_outline().outline_width.is_zero()
 }
 fn compute_damage(old: &ComputedValues, new: &ComputedValues) -> ServoRestyleDamage {
     let mut damage = ServoRestyleDamage::empty();


### PR DESCRIPTION
This reverts commit ae78004b3056c90b66dbba4d92edc0edbc24bc49.
