### PR TITLE
Fixed to ignore trailing whitespace in CSS custom properties.

### DIFF
--- a/style/custom_properties.rs
+++ b/style/custom_properties.rs
@@ -599,6 +599,8 @@ impl VariableValue {
         css.shrink_to_fit();
         references.refs.shrink_to_fit();
 
+        css = css.trim_end().to_owned();
+
         Ok(Self {
             css,
             url_data: url_data.clone(),


### PR DESCRIPTION
## Overview

Remove trailing whitespace when parsing custom properties.

## Motivation

To increase the WPT pass rate for the servo.

## Target test cases

https://wpt.live/css/css-variables/variable-definition.html

Based on my local test results, the outcomes change as follows.

|      | Before | After |
|------|--------|-------|
| Pass | 47     | 59    |
| Fail | 26     | 14    |

I assume the corrections are complete based on the WPT results, but please let me know if there are any other areas that need revision.