### PR TITLE
refactor: simplify Has variant serialization by using serialize_selector_list

### DIFF
--- a/selectors/parser.rs
+++ b/selectors/parser.rs
@@ -2720,14 +2720,7 @@ impl<Impl: SelectorImpl> ToCss for Component<Impl> {
             },
             Has(ref list) => {
                 dest.write_str(":has(")?;
-                let mut first = true;
-                for RelativeSelector { ref selector, .. } in list.iter() {
-                    if !first {
-                        dest.write_str(", ")?;
-                    }
-                    first = false;
-                    selector.to_css(dest)?;
-                }
+                serialize_selector_list(list.iter().map(|rel| &rel.selector), dest)?;
                 dest.write_str(")")
             },
             NonTSPseudoClass(ref pseudo) => pseudo.to_css(dest),


### PR DESCRIPTION
This PR refactors the CSS serialization logic for the `Has` variant in `parser.rs`.  
Instead of manually writing a loop to serialize each `RelativeSelector`, it now reuses the existing helper function `serialize_selector_list`. This reduces duplication and aligns `Has`’s behavior with other variants that already use that helper.