### PR TITLE
Enable prefixed properties for Servo

### DIFF
--- a/style/properties/data.py
+++ b/style/properties/data.py
@@ -848,11 +848,8 @@ class PropertiesData(object):
         return [s for s in self.style_structs if s.longhands]
 
     def add_prefixed_aliases(self, property):
-        # FIXME Servo's DOM architecture doesn't support vendor-prefixed properties.
-        #       See servo/servo#14941.
-        if self.engine == "gecko":
-            for prefix, pref in property.extra_prefixes:
-                property.aliases.append(("-%s-%s" % (prefix, property.name), pref))
+        for prefix, pref in property.extra_prefixes:
+            property.aliases.append(("-%s-%s" % (prefix, property.name), pref))
 
     def declare_longhand(self, name, engines=None, **kwargs):
         engines = engines.split()


### PR DESCRIPTION
There is no reason these cannot be enabled for Servo and it allows more
web content to work.

Servo PR: https://github.com/servo/servo/pull/41350
