### PR TITLE
Enable `layout.css.gradient-color-interpolation-method.enabled`

### DIFF
--- a/stylo_static_prefs/src/lib.rs
+++ b/stylo_static_prefs/src/lib.rs
@@ -42,6 +42,9 @@ macro_rules! pref {
     ("layout.css.font-variations.enabled") => {
         true
     };
+    ("layout.css.gradient-color-interpolation-method.enabled") => {
+        true
+    };
     ($string:literal) => {
         false
     };


### PR DESCRIPTION
Add `layout.css.gradient-color-interpolation-method.enabled` to static prefs.

Fixes https://github.com/servo/servo/issues/41370.

Test case:
```html
<!doctype html>
<body>
    <div id="X" style="width:220px;background:linear-gradient(to right, red 0%, lime 100%);">Example</div>
    <div id="X" style="width:220px;background:linear-gradient(to right in lab, red 0%, lime 100%);">Example</div>
    <div id="X" style="width:220px;background:linear-gradient(in lab, red 0%, lime 100%);">Example</div>
</body>
```

Before the change:
<img width="231" height="67" alt="Screenshot 2025-12-19 at 6 17 51 PM" src="https://github.com/user-attachments/assets/447789c3-0d62-48c4-99d0-57ed57365691" />

After the change:
<img width="230" height="70" alt="Screenshot 2025-12-19 at 6 08 45 PM" src="https://github.com/user-attachments/assets/f6ac737a-4be7-49c8-a2bb-1a00161d88e1" />

Firefox behavior:
<img width="230" height="68" alt="Screenshot 2025-12-19 at 6 08 53 PM" src="https://github.com/user-attachments/assets/01696cce-563d-4770-8008-be1a28ab0299" />
