### PR TITLE
Add layout.css.contrast-color.enabled to static prefs

### DIFF
--- a/stylo_static_prefs/src/lib.rs
+++ b/stylo_static_prefs/src/lib.rs
@@ -45,6 +45,9 @@ macro_rules! pref {
     ("layout.css.gradient-color-interpolation-method.enabled") => {
         true
     };
+    ("layout.css.contrast-color.enabled") => {
+        true
+    };
     ($string:literal) => {
         false
     };


### PR DESCRIPTION
This will enable the `contrast-color()` function in `<color>` productions: https://drafts.csswg.org/css-color-5/#contrast-color