### PR TITLE
Fix mismatched_lifetime_syntaxes warnings

### DIFF
--- a/style/font_face.rs
+++ b/style/font_face.rs
@@ -686,7 +686,7 @@ macro_rules! font_face_descriptors {
             ///
             /// However both are required for the rule to represent an actual font face.
             #[cfg(feature = "servo")]
-            pub fn font_face(&self) -> Option<FontFace> {
+            pub fn font_face(&self) -> Option<FontFace<'_>> {
                 if $( self.$m_ident.is_some() )&&* {
                     Some(FontFace(self))
                 } else {

--- a/style/servo/animation.rs
+++ b/style/servo/animation.rs
@@ -52,7 +52,7 @@ pub struct PropertyAnimation {
 
 impl PropertyAnimation {
     /// Returns the given property longhand id.
-    pub fn property_id(&self) -> PropertyDeclarationId {
+    pub fn property_id(&self) -> PropertyDeclarationId<'_> {
         debug_assert_eq!(self.from.id(), self.to.id());
         self.from.id()
     }

--- a/style/servo/shadow_parts.rs
+++ b/style/servo/shadow_parts.rs
@@ -84,7 +84,7 @@ pub fn parse_part_mapping(input: &str) -> Option<Mapping<'_>> {
 }
 
 /// <https://drafts.csswg.org/css-shadow-parts/#parsing-mapping-list>
-fn parse_mapping_list(input: &str) -> impl Iterator<Item = Mapping> {
+fn parse_mapping_list(input: &str) -> impl Iterator<Item = Mapping<'_>> {
     // Step 1. Let input be the string being parsed.
     // Step 2. Split the string input on commas. Let unparsed mappings be the resulting list of strings.
     let unparsed_mappings = input.split(',');


### PR DESCRIPTION
See https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Servo PR: https://github.com/servo/servo/pull/41690