### PR TITLE
Enable multiple color arguments in `color-mix()`

### DIFF
--- a/stylo_static_prefs/src/lib.rs
+++ b/stylo_static_prefs/src/lib.rs
@@ -37,7 +37,7 @@ macro_rules! default_value {
         false
     };
     ("layout.css.color-mix-multi-color.enabled") => {
-        false
+        true
     };
     ("layout.css.content.alt-text.enabled") => {
         false


### PR DESCRIPTION
Firefox has enabled it by default.

Servo PR: https://github.com/servo/servo/pull/43890

Fixes #339.