### PR TITLE
 Stylo: Enable text-align: match-parent for Servo

### DIFF
--- a/style/values/specified/text.rs
+++ b/style/values/specified/text.rs
@@ -562,7 +562,6 @@ pub enum TextAlign {
     Keyword(TextAlignKeyword),
     /// `match-parent` value of text-align property. It has a different handling
     /// unlike other keywords.
-    #[cfg(feature = "gecko")]
     MatchParent,
     /// This is how we implement the following HTML behavior from
     /// https://html.spec.whatwg.org/#tables-2:
@@ -587,7 +586,6 @@ impl ToComputedValue for TextAlign {
     fn to_computed_value(&self, _context: &Context) -> Self::ComputedValue {
         match *self {
             TextAlign::Keyword(key) => key,
-            #[cfg(feature = "gecko")]
             TextAlign::MatchParent => {
                 // on the root <html> element we should still respect the dir
                 // but the parent dir of that element is LTR even if it's <html dir=rtl>


### PR DESCRIPTION
Removes the `#[cfg(feature = "gecko")]` gate on `TextAlign::MatchParent`
in `style/values/specified/text.rs`, enabling `text-align: match-parent`
for Servo. The computation logic (resolving `start`/`end` to physical
directions based on parent writing mode) was already correct and needed
no changes.

Servo PR: https://github.com/servo/servo/pull/44073