### PR TITLE
Unify Servo's `SharedRwLock` implementation with Gecko

### DIFF
--- a/style/shared_lock.rs
+++ b/style/shared_lock.rs
@@ -5,46 +5,33 @@
 //! Different objects protected by the same lock
 
 use crate::stylesheets::Origin;
-#[cfg(feature = "gecko")]
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
-#[cfg(feature = "servo")]
-use parking_lot::RwLock;
 use servo_arc::Arc;
 use std::cell::UnsafeCell;
 use std::fmt;
-#[cfg(feature = "servo")]
-use std::mem;
-#[cfg(feature = "gecko")]
 use std::ptr;
 use style_traits::{CssString, CssStringWriter};
 use to_shmem::{SharedMemoryBuilder, ToShmem};
 
 /// A shared read/write lock that can protect multiple objects.
 ///
-/// In Gecko builds, we don't need the blocking behavior, just the safety. As
-/// such we implement this with an AtomicRefCell instead in Gecko builds,
-/// which is ~2x as fast, and panics (rather than deadlocking) when things go
-/// wrong (which is much easier to debug on CI).
-///
-/// Servo needs the blocking behavior for its unsynchronized animation setup,
-/// but that may not be web-compatible and may need to be changed (at which
-/// point Servo could use AtomicRefCell too).
+/// We don't need the blocking behavior, just the safety. As such we implement
+/// this with an AtomicRefCell, which is ~2x as fast as an RwLock, and panics
+/// (rather than deadlocking) when things go wrong (which is much easier to
+/// debug on CI).
 ///
 /// Gecko also needs the ability to have "read only" SharedRwLocks, which are
 /// used for objects stored in (read only) shared memory. Attempting to acquire
 /// write access to objects protected by a read only SharedRwLock will panic.
 #[derive(Clone)]
-#[cfg_attr(feature = "servo", derive(crate::derives::MallocSizeOf))]
 pub struct SharedRwLock {
-    #[cfg(feature = "servo")]
-    #[cfg_attr(feature = "servo", ignore_malloc_size_of = "Arc")]
-    arc: Arc<RwLock<()>>,
-
-    #[cfg(feature = "gecko")]
     cell: Option<Arc<AtomicRefCell<SomethingZeroSizedButTyped>>>,
 }
 
-#[cfg(feature = "gecko")]
+#[cfg(feature = "servo")]
+malloc_size_of::malloc_size_of_is_0!(SharedRwLock);
+
+#[cfg_attr(feature = "servo", derive(crate::derives::MallocSizeOf))]
 struct SomethingZeroSizedButTyped;
 
 impl fmt::Debug for SharedRwLock {
@@ -54,32 +41,14 @@ impl fmt::Debug for SharedRwLock {
 }
 
 impl SharedRwLock {
-    /// Create a new shared lock (servo).
-    #[cfg(feature = "servo")]
-    pub fn new() -> Self {
-        SharedRwLock {
-            arc: Arc::new(RwLock::new(())),
-        }
-    }
-
-    /// Create a new shared lock (gecko).
-    #[cfg(feature = "gecko")]
+    /// Create a new shared lock.
     pub fn new() -> Self {
         SharedRwLock {
             cell: Some(Arc::new(AtomicRefCell::new(SomethingZeroSizedButTyped))),
         }
     }
 
-    /// Create a new global shared lock (servo).
-    #[cfg(feature = "servo")]
-    pub fn new_leaked() -> Self {
-        SharedRwLock {
-            arc: Arc::new_leaked(RwLock::new(())),
-        }
-    }
-
-    /// Create a new global shared lock (gecko).
-    #[cfg(feature = "gecko")]
+    /// Create a new global shared lock.
     pub fn new_leaked() -> Self {
         SharedRwLock {
             cell: Some(Arc::new_leaked(AtomicRefCell::new(
@@ -88,13 +57,11 @@ impl SharedRwLock {
         }
     }
 
-    /// Create a new read-only shared lock (gecko).
-    #[cfg(feature = "gecko")]
+    /// Create a new read-only shared lock.
     pub fn read_only() -> Self {
         SharedRwLock { cell: None }
     }
 
-    #[cfg(feature = "gecko")]
     #[inline]
     fn ptr(&self) -> *const SomethingZeroSizedButTyped {
         self.cell
@@ -111,51 +78,22 @@ impl SharedRwLock {
         }
     }
 
-    /// Obtain the lock for reading (servo).
-    #[cfg(feature = "servo")]
-    pub fn read(&self) -> SharedRwLockReadGuard<'_> {
-        mem::forget(self.arc.read());
-        SharedRwLockReadGuard(self)
-    }
-
-    /// Obtain the lock for reading (gecko).
-    #[cfg(feature = "gecko")]
+    /// Obtain the lock for reading.
     pub fn read(&self) -> SharedRwLockReadGuard<'_> {
         SharedRwLockReadGuard(self.cell.as_ref().map(|cell| cell.borrow()))
     }
 
-    /// Obtain the lock for writing (servo).
-    #[cfg(feature = "servo")]
-    pub fn write(&self) -> SharedRwLockWriteGuard<'_> {
-        mem::forget(self.arc.write());
-        SharedRwLockWriteGuard(self)
-    }
-
-    /// Obtain the lock for writing (gecko).
-    #[cfg(feature = "gecko")]
+    /// Obtain the lock for writing.
     pub fn write(&self) -> SharedRwLockWriteGuard<'_> {
         SharedRwLockWriteGuard(self.cell.as_ref().unwrap().borrow_mut())
     }
 }
 
-/// Proof that a shared lock was obtained for reading (servo).
-#[cfg(feature = "servo")]
-pub struct SharedRwLockReadGuard<'a>(&'a SharedRwLock);
-/// Proof that a shared lock was obtained for reading (gecko).
-#[cfg(feature = "gecko")]
+/// Proof that a shared lock was obtained for reading.
 pub struct SharedRwLockReadGuard<'a>(Option<AtomicRef<'a, SomethingZeroSizedButTyped>>);
-#[cfg(feature = "servo")]
-impl<'a> Drop for SharedRwLockReadGuard<'a> {
-    fn drop(&mut self) {
-        // Unsafe: self.lock is private to this module, only ever set after `read()`,
-        // and never copied or cloned (see `compile_time_assert` below).
-        unsafe { self.0.arc.force_unlock_read() }
-    }
-}
 
 impl<'a> SharedRwLockReadGuard<'a> {
     #[inline]
-    #[cfg(feature = "gecko")]
     fn ptr(&self) -> *const SomethingZeroSizedButTyped {
         self.0
             .as_ref()
@@ -164,20 +102,8 @@ impl<'a> SharedRwLockReadGuard<'a> {
     }
 }
 
-/// Proof that a shared lock was obtained for writing (servo).
-#[cfg(feature = "servo")]
-pub struct SharedRwLockWriteGuard<'a>(&'a SharedRwLock);
-/// Proof that a shared lock was obtained for writing (gecko).
-#[cfg(feature = "gecko")]
+/// Proof that a shared lock was obtained for writing.
 pub struct SharedRwLockWriteGuard<'a>(AtomicRefMut<'a, SomethingZeroSizedButTyped>);
-#[cfg(feature = "servo")]
-impl<'a> Drop for SharedRwLockWriteGuard<'a> {
-    fn drop(&mut self) {
-        // Unsafe: self.lock is private to this module, only ever set after `write()`,
-        // and never copied or cloned (see `compile_time_assert` below).
-        unsafe { self.0.arc.force_unlock_write() }
-    }
-}
 
 /// Data protect by a shared lock.
 pub struct Locked<T> {
@@ -198,33 +124,23 @@ impl<T: fmt::Debug> fmt::Debug for Locked<T> {
 }
 
 impl<T> Locked<T> {
-    #[cfg(feature = "gecko")]
     #[inline]
     fn is_read_only_lock(&self) -> bool {
         self.shared_lock.cell.is_none()
     }
 
-    #[cfg(feature = "servo")]
-    fn same_lock_as(&self, lock: &SharedRwLock) -> bool {
-        Arc::ptr_eq(&self.shared_lock.arc, &lock.arc)
-    }
-
-    #[cfg(feature = "gecko")]
     fn same_lock_as(&self, ptr: *const SomethingZeroSizedButTyped) -> bool {
         ptr::eq(self.shared_lock.ptr(), ptr)
     }
 
     /// Access the data for reading.
     pub fn read_with<'a>(&'a self, guard: &'a SharedRwLockReadGuard) -> &'a T {
-        #[cfg(feature = "gecko")]
         assert!(
             self.is_read_only_lock() || self.same_lock_as(guard.ptr()),
             "Locked::read_with called with a guard from an unrelated SharedRwLock: {:?} vs. {:?}",
             self.shared_lock.ptr(),
             guard.ptr(),
         );
-        #[cfg(not(feature = "gecko"))]
-        assert!(self.same_lock_as(&guard.0));
 
         let ptr = self.data.get();
 
@@ -238,7 +154,6 @@ impl<T> Locked<T> {
     }
 
     /// Access the data for reading without verifying the lock. Use with caution.
-    #[cfg(feature = "gecko")]
     pub unsafe fn read_unchecked<'a>(&'a self) -> &'a T {
         let ptr = self.data.get();
         &*ptr
@@ -246,13 +161,10 @@ impl<T> Locked<T> {
 
     /// Access the data for writing.
     pub fn write_with<'a>(&'a self, guard: &'a mut SharedRwLockWriteGuard) -> &'a mut T {
-        #[cfg(feature = "gecko")]
         assert!(
             !self.is_read_only_lock() && self.same_lock_as(&*guard.0),
             "Locked::write_with called with a guard from a read only or unrelated SharedRwLock"
         );
-        #[cfg(not(feature = "gecko"))]
-        assert!(self.same_lock_as(&guard.0));
 
         let ptr = self.data.get();
 
@@ -268,7 +180,6 @@ impl<T> Locked<T> {
     }
 }
 
-#[cfg(feature = "gecko")]
 impl<T: ToShmem> ToShmem for Locked<T> {
     fn to_shmem(&self, builder: &mut SharedMemoryBuilder) -> to_shmem::Result<Self> {
         use std::mem::ManuallyDrop;
@@ -280,13 +191,6 @@ impl<T: ToShmem> ToShmem for Locked<T> {
                 self.read_with(&guard).to_shmem(builder)?,
             )),
         }))
-    }
-}
-
-#[cfg(feature = "servo")]
-impl<T: ToShmem> ToShmem for Locked<T> {
-    fn to_shmem(&self, _builder: &mut SharedMemoryBuilder) -> to_shmem::Result<Self> {
-        panic!("ToShmem not supported in Servo currently")
     }
 }
 


### PR DESCRIPTION
Servo no longer uses the unsynchronized animation setup that's described
in the comment and `AtomicRefCell` is faster than `RwLock`. This change
has Servo use the same locking design that Gecko uses in order to
improve the performance of style locking / unlocking.

Servo PR: servo/servo#44883