### PR TITLE
Enable `mask-*` properties for Servo builds of Stylo

### DIFF
--- a/style/properties/longhands.toml
+++ b/style/properties/longhands.toml
@@ -2364,7 +2364,7 @@ affects = "paint"
 type = "position::HorizontalPosition"
 initial = "computed::LengthPercentage::zero_percent()"
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 extra_prefixes = ["webkit"]
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-position"
 vector = { animation_type = "repeatable_list" }
@@ -2374,7 +2374,7 @@ affects = "paint"
 type = "position::VerticalPosition"
 initial = "computed::LengthPercentage::zero_percent()"
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 extra_prefixes = ["webkit"]
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-position"
 vector = { animation_type = "repeatable_list" }
@@ -2384,7 +2384,7 @@ affects = "paint"
 type = "BackgroundRepeat"
 initial = "computed::BackgroundRepeat::repeat()"
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 extra_prefixes = ["webkit"]
 animation_type = "discrete"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-repeat"
@@ -2395,7 +2395,7 @@ affects = "paint"
 type = "background::BackgroundSize"
 initial = "computed::BackgroundSize::auto()"
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 extra_prefixes = ["webkit"]
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-size"
 vector = { animation_type = "repeatable_list" }
@@ -3925,7 +3925,7 @@ keyword = { values = ["fill", "contain", "cover", "none", "scale-down"] }
 
 [mask-type]
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-type"
 animation_type = "discrete"
 affects = "paint"
@@ -3933,7 +3933,7 @@ keyword = { values = ["luminance", "alpha"] }
 
 [mask-mode]
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-mode"
 animation_type = "discrete"
 affects = "paint"
@@ -3942,7 +3942,7 @@ keyword = { values = ["match-source", "alpha", "luminance"] }
 
 [mask-clip]
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-clip"
 animation_type = "discrete"
 affects = "paint"
@@ -3952,7 +3952,7 @@ keyword = { values = ["border-box", "content-box", "padding-box"], extra_gecko_v
 
 [mask-origin]
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-origin"
 animation_type = "discrete"
 affects = "paint"
@@ -3962,7 +3962,7 @@ keyword = { values = ["border-box", "content-box", "padding-box"], extra_gecko_v
 
 [mask-composite]
 struct = "svg"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-mask-composite"
 animation_type = "discrete"
 affects = "paint"

--- a/style/properties/shorthands.rs
+++ b/style/properties/shorthands.rs
@@ -3561,7 +3561,6 @@ pub mod animation {
     }
 }
 
-#[cfg(feature = "gecko")]
 pub mod mask {
     pub use crate::properties::generated::shorthands::mask::*;
 
@@ -3588,12 +3587,15 @@ pub mod mask {
                 mask_origin::single_value::SpecifiedValue::BorderBox => {
                     mask_clip::single_value::SpecifiedValue::BorderBox
                 },
+                #[cfg(feature = "gecko")]
                 mask_origin::single_value::SpecifiedValue::FillBox => {
                     mask_clip::single_value::SpecifiedValue::FillBox
                 },
+                #[cfg(feature = "gecko")]
                 mask_origin::single_value::SpecifiedValue::StrokeBox => {
                     mask_clip::single_value::SpecifiedValue::StrokeBox
                 },
+                #[cfg(feature = "gecko")]
                 mask_origin::single_value::SpecifiedValue::ViewBox => {
                     mask_clip::single_value::SpecifiedValue::ViewBox
                 },
@@ -3820,8 +3822,18 @@ pub mod mask {
                     writer.item(repeat)?;
                 }
 
-                if has_origin || (has_clip && *clip != Clip::NoClip) {
-                    writer.item(origin)?;
+                #[cfg(feature = "gecko")]
+                {
+                    if has_origin || (has_clip && *clip != Clip::NoClip) {
+                        writer.item(origin)?;
+                    }
+                }
+
+                #[cfg(feature = "servo")]
+                {
+                    if has_origin || has_clip {
+                        writer.item(origin)?;
+                    }
                 }
 
                 if has_clip && *clip != From::from(*origin) {
@@ -3842,7 +3854,6 @@ pub mod mask {
     }
 }
 
-#[cfg(feature = "gecko")]
 pub mod mask_position {
     pub use crate::properties::generated::shorthands::mask_position::*;
 

--- a/style/properties/shorthands.toml
+++ b/style/properties/shorthands.toml
@@ -392,16 +392,16 @@ sub_properties = ["background-position-x", "background-position-y"]
 spec = "https://drafts.csswg.org/css-backgrounds-4/#the-background-position"
 
 [mask]
-engine = "gecko"
 sub_properties = ["mask-mode", "mask-repeat", "mask-clip", "mask-origin", "mask-composite", "mask-position-x", "mask-position-y", "mask-size", "mask-image"]
 spec = "https://drafts.fxtf.org/css-masking/#propdef-mask"
 extra_prefixes = ["webkit"]
+servo_pref = "layout.unimplemented"
 
 [mask-position]
-engine = "gecko"
 sub_properties = ["mask-position-x", "mask-position-y"]
 spec = "https://drafts.csswg.org/css-masks-4/#the-mask-position"
 extra_prefixes = ["webkit"]
+servo_pref = "layout.unimplemented"
 
 [border-radius]
 sub_properties = ["border-top-left-radius", "border-top-right-radius", "border-bottom-right-radius", "border-bottom-left-radius"]


### PR DESCRIPTION
I am hoping to implement masking in Blitz soon, so it would be great if we could enable these properties.

I have followed the existing `layout.unimplemented` convention here, but I'm open to using a Blitz or feature-specific runtime preference, or moving towards a Blitz or feature specific build time flag if that's preferred (at some point we should probably discuss what our long-term strategy for this is?)

Note: for some reason `mask-image` was already enabled (also behind `layout.unimplemented`).

Servo PR: https://github.com/servo/servo/pull/45136