### PR TITLE
Respond to live preference updates in `NonCustomPropertyId::enabled_for_all_content`

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -383,17 +383,15 @@ impl NonCustomPropertyId {
             % if engine == "gecko":
                 unsafe { structs::nsCSSProps_gPropertyEnabled[self.0 as usize] }
             % else:
-                static PREFERENCES: std::sync::LazyLock<[bool; ${len(data.longhands) + len(data.shorthands) + len(data.all_aliases())}]> = std::sync::LazyLock::new(|| [
-                    % for property in data.longhands + data.shorthands + data.all_aliases():
-                        <% preference = getattr(property, "servo_pref") %>
-                        % if preference:
-                    static_prefs::pref!("${preference}"), \
-                        % else:
-                    true, \
-                        % endif %
-                    % endfor
-                    ]);
-                    PREFERENCES[self.0 as usize]
+                match self.0 {
+                % for (index, property) in enumerate(data.longhands + data.shorthands + data.all_aliases()):
+                    <% preference = getattr(property, "servo_pref") %>
+                    % if preference:
+                        ${index} => static_prefs::pref!("${preference}"),
+                    % endif %
+                % endfor
+                    _ => true,
+                }
             % endif
         };
 


### PR DESCRIPTION
Instead of using a `LazyLock` just use a direct match that calls
`static_prefs::pref!`. The idea here is that the compiler can turn this
into a jump table when compilng and that the `static_prefs` call will
reflect the live value of preferences.

Servo PR: servo/servo#45226