### PR TITLE
Bump stylo to 0.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 default-members = ["style"]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 
 [workspace.dependencies]
 # in-repo dependencies (separately versioned)
@@ -27,10 +27,10 @@ to_shmem        = { version = "0.4.0",  path = "./to_shmem", features = ["servo"
 to_shmem_derive = { version = "0.1.0",  path = "./to_shmem_derive" }
 
 # in-repo dependencies (main version)
-malloc_size_of  = { version = "0.17.0", path = "./malloc_size_of", package = "stylo_malloc_size_of", features = ["servo"] }
-static_prefs    = { version = "0.17.0", path = "./stylo_static_prefs", package = "stylo_static_prefs" }
-stylo_atoms     = { version = "0.17.0", path = "./stylo_atoms" }
-dom             = { version = "0.17.0", path = "./stylo_dom", package = "stylo_dom" }
-style_traits    = { version = "0.17.0", path = "./style_traits", features = ["servo"], package = "stylo_traits"}
-style_derive    = { version = "0.17.0", path = "./style_derive", package = "stylo_derive"}
-stylo           = { version = "0.17.0", path = "./style" }
+malloc_size_of  = { version = "0.18.0", path = "./malloc_size_of", package = "stylo_malloc_size_of", features = ["servo"] }
+static_prefs    = { version = "0.18.0", path = "./stylo_static_prefs", package = "stylo_static_prefs" }
+stylo_atoms     = { version = "0.18.0", path = "./stylo_atoms" }
+dom             = { version = "0.18.0", path = "./stylo_dom", package = "stylo_dom" }
+style_traits    = { version = "0.18.0", path = "./style_traits", features = ["servo"], package = "stylo_traits"}
+style_derive    = { version = "0.18.0", path = "./style_derive", package = "stylo_derive"}
+stylo           = { version = "0.18.0", path = "./style" }


### PR DESCRIPTION
d7e4d965d515b55b8d25a7344aa06f9bee4f0f2f is the version servo's 0.3.0 release depends on, so we can just bump stylo on main.