### PR TITLE
Fix typo in `selectors` README

### DIFF
--- a/selectors/README.md
+++ b/selectors/README.md
@@ -6,7 +6,7 @@ rust-selectors
 * [crates.io](https://crates.io/crates/selectors)
 
 CSS Selectors library for Rust.
-Includes parsing and serilization of selectors,
+Includes parsing and serialization of selectors,
 as well as matching against a generic tree of elements.
 Pseudo-elements and most pseudo-classes are generic as well.
 


### PR DESCRIPTION
I noticed a typo in the README file of the `selectors` library.