### PR TITLE
Replace reference to `preferences.rs` with `preferences.toml`

### DIFF
--- a/stylo_static_prefs/build.rs
+++ b/stylo_static_prefs/build.rs
@@ -17,7 +17,7 @@ struct IntegerPreference {
 }
 
 fn main() -> Result<(), std::io::Error> {
-    println!("cargo::rerun-if-changed=preferences.rs");
+    println!("cargo::rerun-if-changed=preferences.toml");
     generate_code(parse_preferences()?)
 }
 


### PR DESCRIPTION
`preferences.rs` doesn't exist, so it was making cargo consider the `stylo_static_prefs` crate to be dirty, even if nothing had changed.

Fixes #380