### PR TITLE
Add "aspect-ratio" media feature.

### DIFF
--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -7,7 +7,7 @@
 use crate::derives::*;
 use crate::queries::feature::{AllowsRanges, Evaluator, FeatureFlags, QueryFeatureDescription};
 use crate::queries::values::PrefersColorScheme;
-use crate::values::computed::{CSSPixelLength, Context, Resolution};
+use crate::values::computed::{CSSPixelLength, Context, Ratio, Resolution};
 use std::fmt::Debug;
 
 /// https://drafts.csswg.org/mediaqueries-4/#width
@@ -129,8 +129,14 @@ fn eval_any_hover(context: &Context, query_value: Option<Hover>) -> bool {
     eval_hover_capabilities(query_value, context.device().all_pointer_capabilities())
 }
 
+/// https://drafts.csswg.org/mediaqueries-4/#aspect-ratio
+fn eval_aspect_ratio(context: &Context) -> Ratio {
+    let size = context.device().au_viewport_size();
+    Ratio::new(size.width.0 as f32, size.height.0 as f32)
+}
+
 /// A list with all the media features that Servo supports.
-pub static MEDIA_FEATURES: [QueryFeatureDescription; 10] = [
+pub static MEDIA_FEATURES: [QueryFeatureDescription; 11] = [
     feature!(
         atom!("width"),
         AllowsRanges::Yes,
@@ -160,6 +166,12 @@ pub static MEDIA_FEATURES: [QueryFeatureDescription; 10] = [
         AllowsRanges::No,
         keyword_evaluator!(eval_any_hover, Hover),
         FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("aspect-ratio"),
+        AllowsRanges::Yes,
+        Evaluator::NumberRatio(eval_aspect_ratio),
+        FeatureFlags::VIEWPORT_DEPENDENT,
     ),
     feature!(
         atom!("scan"),

--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -129,7 +129,7 @@ fn eval_any_hover(context: &Context, query_value: Option<Hover>) -> bool {
     eval_hover_capabilities(query_value, context.device().all_pointer_capabilities())
 }
 
-/// https://drafts.csswg.org/mediaqueries-4/#aspect-ratio
+/// <https://drafts.csswg.org/mediaqueries-4/#aspect-ratio>
 fn eval_aspect_ratio(context: &Context) -> Ratio {
     let size = context.device().au_viewport_size();
     Ratio::new(size.width.0 as f32, size.height.0 as f32)


### PR DESCRIPTION
The implementation does the same as what gecko does (except that I didn't add support for `device-aspect-ratio`, hence slightly simpler / inlined.

Servo PR: https://github.com/servo/servo/pull/45490