### PR TITLE
Remove `overrides_transform_style()` and `get_used_transform_style()`

### DIFF
--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -2121,32 +2121,6 @@ impl ComputedValuesInner {
             &position_style.left,
         ))
     }
-
-    /// Return true if the effects force the transform style to be Flat
-    pub fn overrides_transform_style(&self) -> bool {
-        use crate::computed_values::mix_blend_mode::T as MixBlendMode;
-
-        let effects = self.get_effects();
-        // TODO(gw): Add clip-path, isolation, mask-image, mask-border-source when supported.
-        effects.opacity < 1.0 ||
-           !effects.filter.0.is_empty() ||
-           !effects.clip.is_auto() ||
-           effects.mix_blend_mode != MixBlendMode::Normal
-    }
-
-    /// <https://drafts.csswg.org/css-transforms/#grouping-property-values>
-    pub fn get_used_transform_style(&self) -> computed_values::transform_style::T {
-        use crate::computed_values::transform_style::T as TransformStyle;
-
-        let box_ = self.get_box();
-
-        if self.overrides_transform_style() {
-            TransformStyle::Flat
-        } else {
-            // Return the computed value if not overridden by the above exceptions
-            box_.transform_style
-        }
-    }
 }
 
 /// A reference to a style struct of the parent, or our own style struct.


### PR DESCRIPTION
It's not possible to properly calculate these only looking at style,
because the results depends on the used `overflow` value.

Servo PR: servo/servo#45629
