### PR TITLE
Implement the pointer/hover interaction media features for servo

### DIFF
--- a/style/device/servo.rs
+++ b/style/device/servo.rs
@@ -12,7 +12,7 @@ use crate::logical_geometry::WritingMode;
 use crate::media_queries::MediaType;
 use crate::properties::style_structs::Font;
 use crate::properties::ComputedValues;
-use crate::queries::values::PrefersColorScheme;
+use crate::queries::values::{PointerCapabilities, PrefersColorScheme};
 use crate::values::computed::font::GenericFontFamily;
 use crate::values::computed::{CSSPixelLength, Length, LineHeight, NonNegativeLength};
 use crate::values::specified::color::{ColorSchemeFlags, ForcedColors, SystemColor};
@@ -66,6 +66,10 @@ pub(super) struct ExtraDeviceData {
     /// Whether the user prefers light mode or dark mode
     #[ignore_malloc_size_of = "Pure stack type"]
     prefers_color_scheme: PrefersColorScheme,
+    /// The capabilities of the primary pointing device (for the `pointer` and
+    /// `hover` media features).
+    #[ignore_malloc_size_of = "Pure stack type"]
+    pointer_capabilities: PointerCapabilities,
     /// An implementation of a trait which implements support for querying font metrics.
     #[ignore_malloc_size_of = "Owned by embedder"]
     font_metrics_provider: Box<dyn FontMetricsProvider>,
@@ -108,6 +112,10 @@ impl Device {
                 device_pixel_ratio,
                 quirks_mode,
                 prefers_color_scheme,
+                // Default to a desktop-class input: a precise pointer that can
+                // hover. Embedders on touch-first devices override this via
+                // `set_pointer_capabilities`.
+                pointer_capabilities: PointerCapabilities::FINE | PointerCapabilities::HOVER,
                 font_metrics_provider,
             },
         }
@@ -281,6 +289,28 @@ impl Device {
     /// Returns the color scheme of this [`Device`].
     pub fn color_scheme(&self) -> PrefersColorScheme {
         self.extra.prefers_color_scheme
+    }
+
+    /// Set the [`PointerCapabilities`] of the primary pointing device, used to
+    /// evaluate the `pointer` and `hover` media features.
+    ///
+    /// Note that this does not update any associated `Stylist`. For this you
+    /// must call `Stylist::media_features_change_changed_style` and
+    /// `Stylist::force_stylesheet_origins_dirty`.
+    pub fn set_pointer_capabilities(&mut self, capabilities: PointerCapabilities) {
+        self.extra.pointer_capabilities = capabilities;
+    }
+
+    /// The capabilities of the primary pointing device (`pointer` / `hover`).
+    pub fn pointer_capabilities(&self) -> PointerCapabilities {
+        self.extra.pointer_capabilities
+    }
+
+    /// The union of the capabilities of all pointing devices (`any-pointer` /
+    /// `any-hover`). Servo models a single pointer, so this matches the
+    /// primary device.
+    pub fn any_pointer_capabilities(&self) -> PointerCapabilities {
+        self.extra.pointer_capabilities
     }
 
     pub(crate) fn is_dark_color_scheme(&self, _: ColorSchemeFlags) -> bool {

--- a/style/queries/values.rs
+++ b/style/queries/values.rs
@@ -44,3 +44,19 @@ pub enum PrefersColorScheme {
     Light,
     Dark,
 }
+
+/// The capabilities of the primary (or any) input pointer, used to evaluate
+/// the `pointer`, `any-pointer`, `hover` and `any-hover` media features.
+/// https://drafts.csswg.org/mediaqueries-4/#mf-interaction
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ToShmem)]
+pub struct PointerCapabilities(u8);
+bitflags! {
+    impl PointerCapabilities: u8 {
+        /// The pointer is imprecise (e.g. a touchscreen).
+        const COARSE = 1 << 0;
+        /// The pointer is precise (e.g. a mouse or trackpad).
+        const FINE = 1 << 1;
+        /// The pointer can hover (e.g. a mouse, but not a touchscreen).
+        const HOVER = 1 << 2;
+    }
+}

--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -6,7 +6,7 @@
 
 use crate::derives::*;
 use crate::queries::feature::{AllowsRanges, Evaluator, FeatureFlags, QueryFeatureDescription};
-use crate::queries::values::PrefersColorScheme;
+use crate::queries::values::{PointerCapabilities, PrefersColorScheme};
 use crate::values::computed::{CSSPixelLength, Context, Resolution};
 use std::fmt::Debug;
 
@@ -60,8 +60,75 @@ fn eval_prefers_color_scheme(context: &Context, query_value: Option<PrefersColor
     }
 }
 
+#[derive(Clone, Copy, Debug, FromPrimitive, Parse, ToCss)]
+#[repr(u8)]
+enum Pointer {
+    None,
+    Coarse,
+    Fine,
+}
+
+fn eval_pointer_capabilities(
+    query_value: Option<Pointer>,
+    pointer_capabilities: PointerCapabilities,
+) -> bool {
+    let query_value = match query_value {
+        Some(v) => v,
+        None => return !pointer_capabilities.is_empty(),
+    };
+
+    match query_value {
+        Pointer::None => pointer_capabilities.is_empty(),
+        Pointer::Coarse => pointer_capabilities.intersects(PointerCapabilities::COARSE),
+        Pointer::Fine => pointer_capabilities.intersects(PointerCapabilities::FINE),
+    }
+}
+
+/// https://drafts.csswg.org/mediaqueries-4/#pointer
+fn eval_pointer(context: &Context, query_value: Option<Pointer>) -> bool {
+    eval_pointer_capabilities(query_value, context.device().pointer_capabilities())
+}
+
+/// https://drafts.csswg.org/mediaqueries-4/#descdef-media-any-pointer
+fn eval_any_pointer(context: &Context, query_value: Option<Pointer>) -> bool {
+    eval_pointer_capabilities(query_value, context.device().any_pointer_capabilities())
+}
+
+#[derive(Clone, Copy, Debug, FromPrimitive, Parse, ToCss)]
+#[repr(u8)]
+enum Hover {
+    None,
+    Hover,
+}
+
+fn eval_hover_capabilities(
+    query_value: Option<Hover>,
+    pointer_capabilities: PointerCapabilities,
+) -> bool {
+    let can_hover = pointer_capabilities.intersects(PointerCapabilities::HOVER);
+    let query_value = match query_value {
+        Some(v) => v,
+        None => return can_hover,
+    };
+
+    match query_value {
+        Hover::None => !can_hover,
+        Hover::Hover => can_hover,
+    }
+}
+
+/// https://drafts.csswg.org/mediaqueries-4/#hover
+fn eval_hover(context: &Context, query_value: Option<Hover>) -> bool {
+    eval_hover_capabilities(query_value, context.device().pointer_capabilities())
+}
+
+/// https://drafts.csswg.org/mediaqueries-4/#descdef-media-any-hover
+fn eval_any_hover(context: &Context, query_value: Option<Hover>) -> bool {
+    eval_hover_capabilities(query_value, context.device().any_pointer_capabilities())
+}
+
 /// A list with all the media features that Servo supports.
-pub static MEDIA_FEATURES: [QueryFeatureDescription; 8] = [
+pub static MEDIA_FEATURES: [QueryFeatureDescription; 12] = [
     feature!(
         atom!("width"),
         AllowsRanges::Yes,
@@ -108,6 +175,30 @@ pub static MEDIA_FEATURES: [QueryFeatureDescription; 8] = [
         atom!("prefers-color-scheme"),
         AllowsRanges::No,
         keyword_evaluator!(eval_prefers_color_scheme, PrefersColorScheme),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("pointer"),
+        AllowsRanges::No,
+        keyword_evaluator!(eval_pointer, Pointer),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("any-pointer"),
+        AllowsRanges::No,
+        keyword_evaluator!(eval_any_pointer, Pointer),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("hover"),
+        AllowsRanges::No,
+        keyword_evaluator!(eval_hover, Hover),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("any-hover"),
+        AllowsRanges::No,
+        keyword_evaluator!(eval_any_hover, Hover),
         FeatureFlags::empty(),
     ),
 ];

--- a/stylo_atoms/static_atoms.txt
+++ b/stylo_atoms/static_atoms.txt
@@ -20,6 +20,8 @@ animationcancel
 animationend
 animationiteration
 animationstart
+any-hover
+any-pointer
 aspect-ratio
 beforeinput
 beforetoggle
@@ -71,6 +73,7 @@ hairline
 hashchange
 height
 hidden
+hover
 icecandidate
 iceconnectionstatechange
 icegatheringstatechange
@@ -113,6 +116,7 @@ password
 pause
 play
 playing
+pointer
 popstate
 postershown
 prefers-color-scheme


### PR DESCRIPTION
## Problem

Servo's media-feature list (`style/servo/media_features.rs`) implements none of the [interaction media features](https://drafts.csswg.org/mediaqueries-4/#mf-interaction): `pointer`, `any-pointer`, `hover`, `any-hover`. An unknown feature never matches, so any rules guarded by them are silently dropped.

This bites real stylesheets: modern CSS frameworks (e.g. Tailwind v4) wrap their `:hover` utilities in `@media (hover: hover)`, so on a servo-backed engine all hover styling disappears.

## Fix

Implement the four interaction features, evaluated against a new `PointerCapabilities` carried by the servo `Device` — a `bitflags` of `COARSE` / `FINE` / `HOVER`, mirroring the gecko backend's evaluator shape:

- `stylo_atoms`: add the `pointer` / `any-pointer` / `hover` / `any-hover` feature-name atoms (first commit; builds standalone).
- `style/queries/values.rs`: `PointerCapabilities` (shared feature value).
- `style/servo/media_features.rs`: `Pointer` / `Hover` keyword evaluators + the four `MEDIA_FEATURES` entries.
- `style/device/servo.rs`: a `pointer_capabilities` field defaulting to a desktop-class pointer (`FINE | HOVER`), with `set_pointer_capabilities` for embedders on touch-first devices to override, and `{,any_}pointer_capabilities()` accessors. `any-*` resolves to the same set, as servo models a single pointer.

## Verification

Builds with `--features servo`. Behaviour is exercised end-to-end by integration tests in a downstream consumer (Blitz): `@media (hover: hover)` / `(pointer: fine)` / the bare and `any-*` forms match on the default desktop device, while `(hover: none)` / `(pointer: coarse)` do not.
