### PR TITLE
Implement the `height` and `orientation` media features

### DIFF
--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -6,7 +6,7 @@
 
 use crate::derives::*;
 use crate::queries::feature::{AllowsRanges, Evaluator, FeatureFlags, QueryFeatureDescription};
-use crate::queries::values::PrefersColorScheme;
+use crate::queries::values::{Orientation, PrefersColorScheme};
 use crate::values::computed::{CSSPixelLength, Context, Ratio, Resolution};
 use std::fmt::Debug;
 
@@ -32,6 +32,11 @@ fn eval_device_height(context: &Context) -> CSSPixelLength {
     let device = context.device();
     let scaled = device.device_size() / device.device_pixel_ratio();
     CSSPixelLength::new(scaled.height)
+}
+
+/// https://drafts.csswg.org/mediaqueries-4/#orientation
+fn eval_orientation(context: &Context, value: Option<Orientation>) -> bool {
+    Orientation::eval(context.device().au_viewport_size(), value)
 }
 
 #[derive(Clone, Copy, Debug, FromPrimitive, Parse, ToCss)]
@@ -155,7 +160,7 @@ fn eval_aspect_ratio(context: &Context) -> Ratio {
 }
 
 /// A list with all the media features that Servo supports.
-pub static MEDIA_FEATURES: [QueryFeatureDescription; 14] = [
+pub static MEDIA_FEATURES: [QueryFeatureDescription; 15] = [
     feature!(
         atom!("width"),
         AllowsRanges::Yes,
@@ -166,6 +171,12 @@ pub static MEDIA_FEATURES: [QueryFeatureDescription; 14] = [
         atom!("height"),
         AllowsRanges::Yes,
         Evaluator::Length(eval_height),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("orientation"),
+        AllowsRanges::No,
+        keyword_evaluator!(eval_orientation, Orientation),
         FeatureFlags::empty(),
     ),
     feature!(

--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -15,6 +15,11 @@ fn eval_width(context: &Context) -> CSSPixelLength {
     CSSPixelLength::new(context.device().au_viewport_size().width.to_f32_px())
 }
 
+/// https://drafts.csswg.org/mediaqueries-4/#height
+fn eval_height(context: &Context) -> CSSPixelLength {
+    CSSPixelLength::new(context.device().au_viewport_size().height.to_f32_px())
+}
+
 /// https://drafts.csswg.org/mediaqueries-4/#device-width
 fn eval_device_width(context: &Context) -> CSSPixelLength {
     let device = context.device();
@@ -150,11 +155,17 @@ fn eval_aspect_ratio(context: &Context) -> Ratio {
 }
 
 /// A list with all the media features that Servo supports.
-pub static MEDIA_FEATURES: [QueryFeatureDescription; 13] = [
+pub static MEDIA_FEATURES: [QueryFeatureDescription; 14] = [
     feature!(
         atom!("width"),
         AllowsRanges::Yes,
         Evaluator::Length(eval_width),
+        FeatureFlags::empty(),
+    ),
+    feature!(
+        atom!("height"),
+        AllowsRanges::Yes,
+        Evaluator::Length(eval_height),
         FeatureFlags::empty(),
     ),
     feature!(

--- a/style/servo/media_features.rs
+++ b/style/servo/media_features.rs
@@ -165,19 +165,19 @@ pub static MEDIA_FEATURES: [QueryFeatureDescription; 15] = [
         atom!("width"),
         AllowsRanges::Yes,
         Evaluator::Length(eval_width),
-        FeatureFlags::empty(),
+        FeatureFlags::VIEWPORT_DEPENDENT,
     ),
     feature!(
         atom!("height"),
         AllowsRanges::Yes,
         Evaluator::Length(eval_height),
-        FeatureFlags::empty(),
+        FeatureFlags::VIEWPORT_DEPENDENT,
     ),
     feature!(
         atom!("orientation"),
         AllowsRanges::No,
         keyword_evaluator!(eval_orientation, Orientation),
-        FeatureFlags::empty(),
+        FeatureFlags::VIEWPORT_DEPENDENT,
     ),
     feature!(
         atom!("pointer"),


### PR DESCRIPTION
We were already passing viewport dimensions into Stylo as part of the `Device` which is sufficient to determine, `width`, `height` and `orientation`, but we were previously only exposing the `width` to CSS.|

Servo PR: https://github.com/servo/servo/pull/45707