### PR TITLE
Allow Servo to use computed `@font-face` ranges

### DIFF
--- a/style/font_face.rs
+++ b/style/font_face.rs
@@ -10,6 +10,8 @@ use crate::derives::*;
 use crate::error_reporting::ContextualParseError;
 use crate::parser::{Parse, ParserContext};
 use crate::shared_lock::{SharedRwLockReadGuard, ToCssWithGuard};
+use crate::values::computed::font::FontStyleFixedPoint;
+use crate::values::computed::FontWeight;
 use crate::values::generics::font::FontStyle as GenericFontStyle;
 use crate::values::specified::{url::SpecifiedUrl, Angle};
 use cssparser::{Parser, RuleBodyParser, SourceLocation};
@@ -333,13 +335,17 @@ macro_rules! impl_range {
 pub struct FontWeightRange(pub AbsoluteFontWeight, pub AbsoluteFontWeight);
 impl_range!(FontWeightRange, AbsoluteFontWeight);
 
-/// The computed representation of the above so Gecko can read them easily.
+/// The computed representation of the above so Gecko and Servo can read them easily.
 ///
 /// This one is needed because cbindgen doesn't know how to generate
 /// specified::Number.
 #[repr(C)]
 #[allow(missing_docs)]
-pub struct ComputedFontWeightRange(f32, f32);
+#[cfg_attr(
+    feature = "servo",
+    derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)
+)]
+pub struct ComputedFontWeightRange(pub FontWeight, pub FontWeight);
 
 #[inline]
 fn sort_range<T: PartialOrd>(a: T, b: T) -> (T, T) {
@@ -353,7 +359,7 @@ fn sort_range<T: PartialOrd>(a: T, b: T) -> (T, T) {
 impl FontWeightRange {
     /// Returns a computed font-weight range, or None if either bound is an unresolvable calc.
     pub fn compute(&self) -> Option<ComputedFontWeightRange> {
-        let (min, max) = sort_range(self.0.compute()?.value(), self.1.compute()?.value());
+        let (min, max) = sort_range(self.0.compute()?, self.1.compute()?);
         Some(ComputedFontWeightRange(min, max))
     }
 }
@@ -365,11 +371,15 @@ impl FontWeightRange {
 pub struct FontStretchRange(pub SpecifiedFontStretch, pub SpecifiedFontStretch);
 impl_range!(FontStretchRange, SpecifiedFontStretch);
 
-/// The computed representation of the above, so that Gecko can read them
+/// The computed representation of the above, so that Gecko and Servo can read them
 /// easily.
 #[repr(C)]
 #[allow(missing_docs)]
-pub struct ComputedFontStretchRange(FontStretch, FontStretch);
+#[cfg_attr(
+    feature = "servo",
+    derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)
+)]
+pub struct ComputedFontStretchRange(pub FontStretch, pub FontStretch);
 
 impl FontStretchRange {
     /// Returns a computed font-stretch range, or None if any value contains a calc
@@ -400,13 +410,14 @@ pub enum FontStyle {
     Oblique(Angle, Angle),
 }
 
-/// The computed representation of the above, with angles in degrees, so that
-/// Gecko can read them easily.
+/// The computed representation of the above, with angles in degrees stored as
+/// signed 8.8 fixed-point values, so that Gecko and Servo can read them easily.
 #[repr(u8)]
 #[allow(missing_docs)]
+#[cfg_attr(feature = "servo", derive(Clone, Debug, Deserialize, Serialize))]
 pub enum ComputedFontStyleDescriptor {
     Italic,
-    Oblique(f32, f32),
+    Oblique(FontStyleFixedPoint, FontStyleFixedPoint),
 }
 
 impl Parse for FontStyle {
@@ -474,7 +485,10 @@ impl FontStyle {
                 let first = SpecifiedFontStyle::compute_angle_degrees(first)?;
                 let second = SpecifiedFontStyle::compute_angle_degrees(second)?;
                 let (min, max) = sort_range(first, second);
-                Some(ComputedFontStyleDescriptor::Oblique(min, max))
+                Some(ComputedFontStyleDescriptor::Oblique(
+                    FontStyleFixedPoint::from_float(min),
+                    FontStyleFixedPoint::from_float(max),
+                ))
             },
         }
     }


### PR DESCRIPTION
Performs some changes so that Servo will be able to use these:
- `ComputedFontWeightRange`
- `ComputedFontStretchRange`
- `ComputedFontStyleDescriptor`

Servo PR: https://github.com/servo/servo/pull/45821