### PR TITLE
Make `iterate_by()` increment the iteration state for infinite animations

### DIFF
--- a/style/servo/animation.rs
+++ b/style/servo/animation.rs
@@ -606,8 +606,13 @@ impl Animation {
             return 0.;
         }
 
-        if let KeyframesIterationState::Finite(ref mut current, max) = self.iteration_state {
-            *current = (*current + n).min(max);
+        match self.iteration_state {
+            KeyframesIterationState::Finite(ref mut current, max) => {
+                *current = (*current + n).min(max);
+            },
+            KeyframesIterationState::Infinite(ref mut current) => {
+                *current += n;
+            },
         }
 
         if let AnimationState::Paused(ref mut progress) = self.state {


### PR DESCRIPTION
It was only incremented for finite animations, but infinite animations need to be incremented too.

Servo PR: https://github.com/servo/servo/pull/45990