### PR TITLE
Relax assert for paused animations to include equality

### DIFF
--- a/style/servo/animation.rs
+++ b/style/servo/animation.rs
@@ -616,7 +616,7 @@ impl Animation {
         }
 
         if let AnimationState::Paused(ref mut progress) = self.state {
-            debug_assert!(*progress > n);
+            debug_assert!(*progress >= n);
             *progress -= n;
         }
 


### PR DESCRIPTION
It's fine to subtract `n` when the value is `n`, we just don't want to get negative.