### PR TITLE
Add a setter for the media_type to `Device`

### DIFF
--- a/style/device/servo.rs
+++ b/style/device/servo.rs
@@ -260,6 +260,15 @@ impl Device {
             .query_font_metrics(vertical, font, base_size, flags)
     }
 
+    /// Set the media type on this [`Device`].
+    ///
+    /// Note that this does not update any associated `Stylist`. For this you must call
+    /// `Stylist::media_features_change_changed_style` and
+    /// `Stylist::force_stylesheet_origins_dirty`.
+    pub fn set_media_type(&mut self, media_type: MediaType) {
+        self.extra.media_type = media_type;
+    }
+
     /// Return the media type of the current device.
     pub fn media_type(&self) -> MediaType {
         self.extra.media_type.clone()


### PR DESCRIPTION
This mirrors setters that are already available for the other "media data" field, and is needed to update the media type without recreating the `Device` (which can cause state synchronisation issues with the fields of `Device` that are computed internally by Stylo).