### PR TITLE
Enable scrollbar-color/scrollbar-width for the servo engine

### DIFF
--- a/style/properties/longhands.toml
+++ b/style/properties/longhands.toml
@@ -1854,7 +1854,7 @@ affects = "paint"
 type = "ScrollbarColor"
 initial = "Default::default()"
 struct = "inherited_ui"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.csswg.org/css-scrollbars-1/#scrollbar-color"
 boxed = true
 ignored_when_colors_disabled = true
@@ -4104,7 +4104,7 @@ keyword = { values = ["auto", "normal", "active", "disabled", "inactive"] }
 
 [scrollbar-width]
 struct = "ui"
-engine = "gecko"
+servo_pref = "layout.unimplemented"
 spec = "https://drafts.csswg.org/css-scrollbars-1/#scrollbar-width"
 animation_type = "discrete"
 affects = "layout"


### PR DESCRIPTION
Both css-scrollbars-1 properties were gated `engine="gecko"` in `longhands.toml`, but their value types and parsers are engine-neutral. Removing the gate lets the servo configuration parse, compute, and expose them (`scrollbar-color` in inherited_ui, `scrollbar-width` in ui), so servo-engine consumers can implement css-scrollbars-1 rendering. Unblocks blitz scrollbars PR.

Servo companion: https://github.com/servo/servo/pull/46256