### PR TITLE
Share Stylo's Servo-specific derives with Gecko

### DIFF
--- a/style/color/mod.rs
+++ b/style/color/mod.rs
@@ -27,8 +27,7 @@ pub const PRE_ALLOCATED_COLOR_MIX_ITEMS: usize = 3;
 pub type ColorMixItemList<T> = smallvec::SmallVec<[T; PRE_ALLOCATED_COLOR_MIX_ITEMS]>;
 
 /// The 3 components that make up a color.  (Does not include the alpha component)
-#[derive(Copy, Clone, Debug, MallocSizeOf, PartialEq, ToShmem)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Copy, Clone, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize, ToShmem)]
 #[repr(C)]
 pub struct ColorComponents(pub f32, pub f32, pub f32);
 
@@ -85,17 +84,18 @@ impl std::ops::Div for ColorComponents {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     ToAnimatedValue,
     ToComputedValue,
     ToCss,
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(u8)]
 pub enum ColorSpace {
     /// A color specified in the sRGB color space with either the rgb/rgba(..)
@@ -243,8 +243,7 @@ bitflags! {
 
 /// An absolutely specified color, using either rgb(), rgba(), lab(), lch(),
 /// oklab(), oklch() or color().
-#[derive(Copy, Clone, Debug, MallocSizeOf, ToShmem, ToTyped)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Copy, Clone, Debug, Deserialize, MallocSizeOf, Serialize, ToShmem, ToTyped)]
 #[repr(C)]
 #[typed(todo_derive_fields)]
 pub struct AbsoluteColor {

--- a/style/counter_style/mod.rs
+++ b/style/counter_style/mod.rs
@@ -29,15 +29,16 @@ pub use crate::properties::counter_style::{DescriptorId, DescriptorParser, Descr
 
 /// https://drafts.csswg.org/css-counter-styles/#typedef-symbols-type
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     ToComputedValue,
     ToCss,
     ToResolvedValue,

--- a/style/font_face.rs
+++ b/style/font_face.rs
@@ -69,8 +69,9 @@ impl Parse for SourceList {
 
 /// Keywords for the font-face src descriptor's format() function.
 /// ('None' and 'Unknown' are for internal use in gfx, not exposed to CSS.)
-#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToCss, ToShmem)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(
+    Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, Parse, PartialEq, Serialize, ToCss, ToShmem,
+)]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum FontFaceSourceFormatKeyword {
@@ -89,8 +90,7 @@ pub enum FontFaceSourceFormatKeyword {
 
 /// Flags for the @font-face tech() function, indicating font technologies
 /// required by the resource.
-#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToShmem)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize, ToShmem)]
 #[repr(C)]
 pub struct FontFaceSourceTechFlags(u16);
 bitflags! {
@@ -236,8 +236,7 @@ pub enum FontFaceSourceListComponent {
     TechFlags(FontFaceSourceTechFlags),
 }
 
-#[derive(Clone, Debug, Eq, MallocSizeOf, PartialEq, ToCss, ToShmem)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Debug, Deserialize, Eq, MallocSizeOf, PartialEq, Serialize, ToCss, ToShmem)]
 #[repr(u8)]
 #[allow(missing_docs)]
 pub enum FontFaceSourceFormat {
@@ -284,9 +283,19 @@ impl ToCss for UrlSource {
 /// The font-display descriptor determines how a font face is displayed based
 /// on whether and when it is downloaded and ready to use.
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
-    Clone, Copy, Debug, Eq, MallocSizeOf, Parse, PartialEq, ToComputedValue, ToCss, ToShmem,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    MallocSizeOf,
+    Parse,
+    PartialEq,
+    Serialize,
+    ToComputedValue,
+    ToCss,
+    ToShmem,
 )]
 #[repr(u8)]
 pub enum FontDisplay {
@@ -340,10 +349,7 @@ impl_range!(FontWeightRange, AbsoluteFontWeight);
 /// specified::Number.
 #[repr(C)]
 #[allow(missing_docs)]
-#[cfg_attr(
-    feature = "servo",
-    derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)
-)]
+#[derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct ComputedFontWeightRange(pub FontWeight, pub FontWeight);
 
 #[inline]
@@ -374,10 +380,7 @@ impl_range!(FontStretchRange, SpecifiedFontStretch);
 /// easily.
 #[repr(C)]
 #[allow(missing_docs)]
-#[cfg_attr(
-    feature = "servo",
-    derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)
-)]
+#[derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct ComputedFontStretchRange(pub FontStretch, pub FontStretch);
 
 impl FontStretchRange {
@@ -413,10 +416,7 @@ pub enum FontStyleRange {
 /// signed 8.8 fixed-point values, so that Gecko and Servo can read them easily.
 #[repr(C)]
 #[allow(missing_docs)]
-#[cfg_attr(
-    feature = "servo",
-    derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)
-)]
+#[derive(Clone, Debug, Deserialize, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct ComputedFontStyleRange(pub FontStyle, pub FontStyle);
 
 impl Parse for FontStyleRange {

--- a/style/logical_geometry.rs
+++ b/style/logical_geometry.rs
@@ -422,13 +422,11 @@ impl fmt::Display for WritingMode {
 /// (in addition to taking it as a parameter to methods) and check it.
 /// In non-debug builds, make this storage zero-size and the checks no-ops.
 #[cfg(not(debug_assertions))]
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 struct DebugWritingMode;
 
 #[cfg(debug_assertions)]
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 struct DebugWritingMode {
     mode: WritingMode,
 }
@@ -478,16 +476,14 @@ impl Debug for DebugWritingMode {
 }
 
 // Used to specify the logical direction.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum Direction {
     Inline,
     Block,
 }
 
 /// A 2D size in flow-relative dimensions
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct LogicalSize<T> {
     pub inline: T, // inline-size, a.k.a. logical width, a.k.a. measure
     pub block: T,  // block-size, a.k.a. logical height, a.k.a. extent
@@ -629,8 +625,7 @@ impl<T: Sub<T, Output = T>> Sub for LogicalSize<T> {
 }
 
 /// A 2D point in flow-relative dimensions
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct LogicalPoint<T> {
     /// inline-axis coordinate
     pub i: T,
@@ -867,8 +862,7 @@ impl<T: Copy + Sub<T, Output = T>> Sub<LogicalSize<T>> for LogicalPoint<T> {
 /// Represents the four sides of the margins, borders, or padding of a CSS box,
 /// or a combination of those.
 /// A positive "margin" can be added to a rectangle to obtain a bigger rectangle.
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct LogicalMargin<T> {
     pub block_start: T,
     pub inline_end: T,
@@ -1230,8 +1224,7 @@ impl<T: Sub<T, Output = T>> Sub for LogicalMargin<T> {
 }
 
 /// A rectangle in flow-relative dimensions
-#[derive(Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Serialize))]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct LogicalRect<T> {
     pub start: LogicalPoint<T>,
     pub size: LogicalSize<T>,

--- a/style/properties/computed_value_flags.rs
+++ b/style/properties/computed_value_flags.rs
@@ -4,6 +4,8 @@
 
 //! Misc information about a given computed style.
 
+use crate::derives::MallocSizeOf;
+
 /// Misc information about a given computed style.
 ///
 /// All flags are currently inherited for text, pseudo elements, and
@@ -11,8 +13,7 @@
 /// If we ever want to add some flags that shouldn't inherit for them,
 /// we might want to add a function to handle this.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "servo", derive(crate::derives::MallocSizeOf))]
+#[derive(Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq)]
 pub struct ComputedValueFlags(u32);
 
 bitflags! {

--- a/style/properties/helpers.mako.rs
+++ b/style/properties/helpers.mako.rs
@@ -193,8 +193,26 @@ pub mod ${property.ident} {
     pub mod computed_value {
         #[allow(unused_imports)]
         use crate::derives::*;
-        #[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
-        #[derive(Clone, Copy, Debug, Eq, FromPrimitive, MallocSizeOf, Parse, PartialEq, SpecifiedValueInfo, ToAnimatedValue, ToComputedValue, ToCss, ToResolvedValue, ToShmem, ToTyped)]
+        #[derive(
+            Clone,
+            Copy,
+            Debug,
+            Deserialize,
+            Eq,
+            FromPrimitive,
+            Hash,
+            MallocSizeOf,
+            Parse,
+            PartialEq,
+            Serialize,
+            SpecifiedValueInfo,
+            ToAnimatedValue,
+            ToComputedValue,
+            ToCss,
+            ToResolvedValue,
+            ToShmem,
+            ToTyped,
+        )]
         pub enum T {
         % for variant in property.keyword.values_for(engine):
         <%

--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1289,8 +1289,7 @@ pub mod style_structs {
 
     % for style_struct in data.active_style_structs():
         % if style_struct.name == "Font":
-        #[derive(Clone, Debug, MallocSizeOf)]
-        #[cfg_attr(feature = "servo", derive(Serialize, Deserialize))]
+        #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
         % else:
         #[derive(Clone, Debug, MallocSizeOf, PartialEq)]
         % endif
@@ -1587,7 +1586,7 @@ pub mod style_structs {
 pub use super::gecko::{ComputedValues, ComputedValuesInner};
 
 #[cfg(feature = "servo")]
-#[cfg_attr(feature = "servo", derive(Clone, Debug))]
+#[derive(Clone, Debug)]
 /// Actual data of ComputedValues, to match up with Gecko
 pub struct ComputedValuesInner {
     % for style_struct in data.active_style_structs():
@@ -1625,7 +1624,7 @@ pub struct ComputedValuesInner {
 ///
 /// When needed, the structs may be copied in order to get mutated.
 #[cfg(feature = "servo")]
-#[cfg_attr(feature = "servo", derive(Clone, Debug))]
+#[derive(Clone, Debug)]
 pub struct ComputedValues {
     /// The actual computed values
     ///

--- a/style/properties_and_values/registry.rs
+++ b/style/properties_and_values/registry.rs
@@ -29,8 +29,7 @@ pub struct PropertyRegistration {
 
 /// The script registry of custom properties.
 /// <https://drafts.css-houdini.org/css-properties-values-api-1/#dom-window-registeredpropertyset-slot>
-#[derive(Default)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Default, MallocSizeOf)]
 pub struct ScriptRegistry {
     properties: PrecomputedHashMap<Atom, PropertyRegistration>,
 }

--- a/style/selector_parser.rs
+++ b/style/selector_parser.rs
@@ -39,7 +39,7 @@ pub use crate::servo::restyle_damage::ServoRestyleDamage as RestyleDamage;
 pub use crate::gecko::restyle_damage::GeckoRestyleDamage as RestyleDamage;
 
 /// Servo's selector parser.
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(MallocSizeOf)]
 pub struct SelectorParser<'a> {
     /// The origin of the stylesheet we're parsing.
     pub stylesheet_origin: Origin,

--- a/style/servo/attr.rs
+++ b/style/servo/attr.rs
@@ -33,16 +33,14 @@ use crate::{Atom, LocalName, Namespace, Prefix};
 // Duplicated from script::dom::values.
 const UNSIGNED_LONG_MAX: u32 = 2147483647;
 
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq)]
 pub enum LengthOrPercentageOrAuto {
     Auto,
     Percentage(f32),
     Length(Au),
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub enum AttrValue {
     //
     // Variants that are stored in their serialized form.
@@ -707,8 +705,7 @@ pub fn parse_length(mut value: &str) -> LengthOrPercentageOrAuto {
 }
 
 /// A struct that uniquely identifies an element's attribute.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Debug, MallocSizeOf)]
 pub struct AttrIdentifier {
     pub local_name: LocalName,
     pub name: LocalName,

--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -545,8 +545,7 @@ impl NonTSPseudoClass {
 
 /// The abstract struct we implement the selector parser implementation on top
 /// of.
-#[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq)]
 pub struct SelectorImpl;
 
 /// A set of extra data to carry along with the matching context, either for

--- a/style/shared_lock.rs
+++ b/style/shared_lock.rs
@@ -4,6 +4,7 @@
 
 //! Different objects protected by the same lock
 
+use crate::derives::MallocSizeOf;
 use crate::stylesheets::Origin;
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut};
 use servo_arc::Arc;
@@ -31,7 +32,7 @@ pub struct SharedRwLock {
 #[cfg(feature = "servo")]
 malloc_size_of::malloc_size_of_is_0!(SharedRwLock);
 
-#[cfg_attr(feature = "servo", derive(crate::derives::MallocSizeOf))]
+#[derive(MallocSizeOf)]
 struct SomethingZeroSizedButTyped;
 
 impl fmt::Debug for SharedRwLock {

--- a/style/stylesheet_set.rs
+++ b/style/stylesheet_set.rs
@@ -311,7 +311,7 @@ where
 }
 
 /// The set of stylesheets effective for a given document.
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(MallocSizeOf)]
 pub struct DocumentStylesheetSet<S>
 where
     S: StylesheetInDocument + PartialEq + 'static,

--- a/style/stylesheets/stylesheet.rs
+++ b/style/stylesheets/stylesheet.rs
@@ -285,11 +285,8 @@ impl StylesheetInDocument for Stylesheet {
 
 /// A simple wrapper over an `Arc<Stylesheet>`, with pointer comparison, and
 /// suitable for its use in a `StylesheetSet`.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-pub struct DocumentStyleSheet(
-    #[cfg_attr(feature = "servo", ignore_malloc_size_of = "Arc")] pub Arc<Stylesheet>,
-);
+#[derive(Clone, Debug, MallocSizeOf)]
+pub struct DocumentStyleSheet(#[ignore_malloc_size_of = "Arc"] pub Arc<Stylesheet>);
 
 impl PartialEq for DocumentStyleSheet {
     fn eq(&self, other: &Self) -> bool {

--- a/style/values/animated/transform.rs
+++ b/style/values/animated/transform.rs
@@ -30,8 +30,7 @@ use std::ops::Add;
 // Animations for Matrix/Matrix3D.
 // ------------------------------------
 /// A 2d matrix for interpolation.
-#[derive(Clone, ComputeSquaredDistance, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 #[allow(missing_docs)]
 // FIXME: We use custom derive for ComputeSquaredDistance. However, If possible, we should convert
 // the InnerMatrix2D into types with physical meaning. This custom derive computes the squared
@@ -56,13 +55,11 @@ impl Animate for InnerMatrix2D {
 }
 
 /// A 2d translation function.
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug)]
+#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct Translate2D(f32, f32);
 
 /// A 2d scale function.
-#[derive(Clone, ComputeSquaredDistance, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct Scale2D(f32, f32);
 
 impl Animate for Scale2D {
@@ -75,8 +72,7 @@ impl Animate for Scale2D {
 }
 
 /// A decomposed 2d matrix.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Debug, MallocSizeOf)]
 pub struct MatrixDecomposed2D {
     /// The translation function.
     pub translate: Translate2D,
@@ -275,13 +271,11 @@ impl Animate for Matrix {
 }
 
 /// A 3d translation.
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug)]
+#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct Translate3D(pub f32, pub f32, pub f32);
 
 /// A 3d scale function.
-#[derive(Clone, ComputeSquaredDistance, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct Scale3D(pub f32, pub f32, pub f32);
 
 impl Scale3D {
@@ -304,8 +298,7 @@ impl Animate for Scale3D {
 }
 
 /// A 3d skew function.
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-#[derive(Animate, Clone, Copy, Debug)]
+#[derive(Animate, Clone, Copy, Debug, MallocSizeOf)]
 pub struct Skew(f32, f32, f32);
 
 impl ComputeSquaredDistance for Skew {
@@ -320,8 +313,7 @@ impl ComputeSquaredDistance for Skew {
 }
 
 /// A 3d perspective transformation.
-#[derive(Clone, ComputeSquaredDistance, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct Perspective(pub f32, pub f32, pub f32, pub f32);
 
 impl Animate for Perspective {
@@ -336,8 +328,7 @@ impl Animate for Perspective {
 }
 
 /// A quaternion used to represent a rotation.
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Debug, MallocSizeOf)]
 pub struct Quaternion(f64, f64, f64, f64);
 
 impl Quaternion {
@@ -499,8 +490,7 @@ impl ComputeSquaredDistance for Quaternion {
 }
 
 /// A decomposed 3d matrix.
-#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Animate, Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf)]
 pub struct MatrixDecomposed3D {
     /// A translation function.
     pub translate: Translate3D,

--- a/style/values/computed/box.rs
+++ b/style/values/computed/box.rs
@@ -65,9 +65,20 @@ pub type Perspective = GenericPerspective<NonNegativeLength>;
 
 /// A computed value for the `resize` property.
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, MallocSizeOf, Parse, PartialEq, ToCss, ToResolvedValue, ToTyped,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    MallocSizeOf,
+    Parse,
+    PartialEq,
+    Serialize,
+    ToCss,
+    ToResolvedValue,
+    ToTyped,
 )]
 #[repr(u8)]
 pub enum Resize {
@@ -130,13 +141,14 @@ impl ToComputedValue for specified::Resize {
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     ToResolvedValue,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct Zoom(f32);
 

--- a/style/values/computed/font.rs
+++ b/style/values/computed/font.rs
@@ -65,14 +65,15 @@ pub use crate::values::specified::Number as SpecifiedNumber;
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     Hash,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     ToResolvedValue,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct FixedPoint<T, const FRACTION_BITS: u16> {
     /// The actual representation.
     pub value: T,
@@ -142,13 +143,14 @@ pub type FontWeightFixedPoint = FixedPoint<u16, FONT_WEIGHT_FRACTION_BITS>;
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Hash,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     ToResolvedValue,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct FontWeight(FontWeightFixedPoint);
 impl ToAnimatedValue for FontWeight {
@@ -261,13 +263,14 @@ impl FontWeight {
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     ToAnimatedZero,
     ToCss,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Serialize, Deserialize))]
 /// The computed value of font-size
 pub struct FontSize {
     /// The computed size, that we use to compute ems etc. This accounts for
@@ -353,8 +356,18 @@ impl ToResolvedValue for FontSize {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, ToComputedValue, ToResolvedValue, ToTyped)]
-#[cfg_attr(feature = "servo", derive(Hash, Serialize, Deserialize))]
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    PartialEq,
+    Serialize,
+    ToComputedValue,
+    ToResolvedValue,
+    ToTyped,
+)]
 /// Specifies a prioritized list of font family names or generic family names.
 #[repr(C)]
 #[typed(todo_derive_fields)]
@@ -499,9 +512,18 @@ impl ToCss for FontFamily {
 
 /// The name of a font family of choice.
 #[derive(
-    Clone, Debug, Eq, Hash, MallocSizeOf, PartialEq, ToComputedValue, ToResolvedValue, ToShmem,
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    MallocSizeOf,
+    PartialEq,
+    Serialize,
+    ToComputedValue,
+    ToResolvedValue,
+    ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct FamilyName {
     /// Name of the font family.
@@ -559,9 +581,19 @@ impl ToCss for FamilyName {
 }
 
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, MallocSizeOf, PartialEq, ToComputedValue, ToResolvedValue, ToShmem,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    MallocSizeOf,
+    PartialEq,
+    Serialize,
+    ToComputedValue,
+    ToResolvedValue,
+    ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 /// Font family names must either be given quoted as strings,
 /// or unquoted as a sequence of one or more identifiers.
 #[repr(u8)]
@@ -578,9 +610,19 @@ pub enum FontFamilyNameSyntax {
 /// A set of faces that vary in weight, width or slope.
 /// cbindgen:derive-mut-casts=true
 #[derive(
-    Clone, Debug, Eq, MallocSizeOf, PartialEq, ToCss, ToComputedValue, ToResolvedValue, ToShmem,
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    MallocSizeOf,
+    PartialEq,
+    Serialize,
+    ToCss,
+    ToComputedValue,
+    ToResolvedValue,
+    ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize, Hash))]
 #[repr(u8)]
 pub enum SingleFontFamily {
     /// The name of a font family of choice.
@@ -611,17 +653,18 @@ fn math_enabled(context: &ParserContext) -> bool {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     Hash,
     MallocSizeOf,
     PartialEq,
     Parse,
+    Serialize,
     ToCss,
     ToComputedValue,
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(u32)]
 #[allow(missing_docs)]
 pub enum GenericFontFamily {
@@ -724,8 +767,18 @@ impl Parse for SingleFontFamily {
 }
 
 /// A list of font families.
-#[derive(Clone, Debug, ToComputedValue, ToResolvedValue, ToShmem, PartialEq, Eq)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize, Hash))]
+#[derive(
+    Clone,
+    Debug,
+    Deserialize,
+    Hash,
+    Serialize,
+    ToComputedValue,
+    ToResolvedValue,
+    ToShmem,
+    PartialEq,
+    Eq,
+)]
 #[repr(C)]
 pub struct FontFamilyList {
     /// The actual list of font families specified.
@@ -1000,9 +1053,11 @@ where
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToResolvedValue,
@@ -1010,7 +1065,6 @@ where
     ToTyped,
 )]
 #[repr(C)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[typed(todo_derive_fields)]
 #[value_info(other_values = "normal")]
 pub struct FontLanguageOverride(pub u32);
@@ -1147,15 +1201,16 @@ pub type FontStyleFixedPoint = FixedPoint<i16, FONT_STYLE_FRACTION_BITS>;
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     Hash,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     ToResolvedValue,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 #[typed(todo_derive_fields)]
 pub struct FontStyle(FontStyleFixedPoint);
@@ -1264,9 +1319,18 @@ pub type FontStretchFixedPoint = FixedPoint<u16, FONT_STRETCH_FRACTION_BITS>;
 /// cbindgen:derive-gt
 /// cbindgen:derive-gte
 #[derive(
-    Clone, ComputeSquaredDistance, Copy, Debug, MallocSizeOf, PartialEq, PartialOrd, ToResolvedValue,
+    Clone,
+    ComputeSquaredDistance,
+    Copy,
+    Debug,
+    Deserialize,
+    Hash,
+    MallocSizeOf,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    ToResolvedValue,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 #[repr(C)]
 pub struct FontStretch(pub FontStretchFixedPoint);
 

--- a/style/values/generics/basic_shape.rs
+++ b/style/values/generics/basic_shape.rs
@@ -69,17 +69,18 @@ fn is_default_box_for_clip_path(b: &ShapeGeometryBox) -> bool {
 
 /// https://drafts.csswg.org/css-shapes-1/#typedef-shape-box
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,
     Copy,
     ComputeSquaredDistance,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,

--- a/style/values/generics/effects.rs
+++ b/style/values/generics/effects.rs
@@ -39,13 +39,14 @@ pub struct GenericBoxShadow<Color, SizeLength, BlurShapeLength, ShapeLength> {
 pub use self::GenericBoxShadow as BoxShadow;
 
 /// A generic value for a single `filter`.
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     ComputeSquaredDistance,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,

--- a/style/values/generics/font.rs
+++ b/style/values/generics/font.rs
@@ -27,16 +27,18 @@ pub trait TaggedFontValue {
 #[derive(
     Clone,
     Debug,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 pub struct FeatureTagValue<Integer> {
     /// A four-character tag, packed into a u32 (one byte per character).
     pub tag: FontTag,
@@ -77,9 +79,11 @@ where
     Clone,
     ComputeSquaredDistance,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,
@@ -87,7 +91,6 @@ where
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub struct VariationValue<Number> {
     /// A four-character tag, packed into a u32 (one byte per character).
     #[animation(constant)]
@@ -106,9 +109,12 @@ impl<T> TaggedFontValue for VariationValue<T> {
 #[derive(
     Clone,
     Debug,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToCss,
@@ -116,7 +122,6 @@ impl<T> TaggedFontValue for VariationValue<T> {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 #[css(comma)]
 #[typed(todo_derive_fields)]
 pub struct FontSettings<T>(#[css(if_empty = "normal", iterable)] pub Box<[T]>);
@@ -160,16 +165,18 @@ impl<T: Parse> Parse for FontSettings<T> {
 #[derive(
     Clone,
     Copy,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 pub struct FontTag(pub u32);
 
 impl fmt::Debug for FontTag {
@@ -222,16 +229,17 @@ impl Parse for FontTag {
 ///
 /// https://drafts.csswg.org/css-fonts-4/#font-style-prop
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToAnimatedZero,
@@ -265,9 +273,11 @@ impl<Angle: Zero> FontStyle<Angle> {
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToAnimatedZero,
@@ -275,7 +285,6 @@ impl<Angle: Zero> FontStyle<Angle> {
     ToResolvedValue,
     ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Serialize, Deserialize))]
 pub enum GenericFontSizeAdjust<Factor> {
     #[animation(error)]
     None,
@@ -330,8 +339,10 @@ impl<Factor: ToTyped> ToTyped for GenericFontSizeAdjust<Factor> {
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToCss,
@@ -339,7 +350,6 @@ impl<Factor: ToTyped> ToTyped for GenericFontSizeAdjust<Factor> {
     Parse,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C, u8)]
 pub enum GenericLineHeight<N, L> {
     /// `normal`

--- a/style/values/generics/image.rs
+++ b/style/values/generics/image.rs
@@ -298,15 +298,16 @@ pub use self::GenericEllipse as Ellipse;
 
 /// <https://drafts.csswg.org/css-images/#typedef-extent-keyword>
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     ToComputedValue,
     ToCss,
     ToResolvedValue,
@@ -372,14 +373,13 @@ impl<Color, T> ColorStop<Color, T> {
 
 /// Specified values for a paint worklet.
 /// <https://drafts.css-houdini.org/css-paint-api/>
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
-#[derive(Clone, Debug, PartialEq, ToComputedValue, ToResolvedValue, ToShmem)]
+#[derive(Clone, Debug, MallocSizeOf, PartialEq, ToComputedValue, ToResolvedValue, ToShmem)]
 pub struct PaintWorklet {
     /// The name the worklet was registered with.
     pub name: Atom,
     /// The arguments for the worklet.
     /// TODO: store a parsed representation of the arguments.
-    #[cfg_attr(feature = "servo", ignore_malloc_size_of = "Arc")]
+    #[ignore_malloc_size_of = "Arc"]
     #[compute(no_field_bound)]
     #[resolve(no_field_bound)]
     pub arguments: Vec<Arc<custom_properties::SpecifiedValue>>,

--- a/style/values/generics/length.rs
+++ b/style/values/generics/length.rs
@@ -29,8 +29,10 @@ use style_traits::{CssWriter, SpecifiedValueInfo};
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToAnimatedZero,
@@ -40,7 +42,6 @@ use style_traits::{CssWriter, SpecifiedValueInfo};
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C, u8)]
 pub enum GenericLengthPercentageOrAuto<LengthPercent> {
     LengthPercentage(LengthPercent),

--- a/style/values/generics/mod.rs
+++ b/style/values/generics/mod.rs
@@ -93,16 +93,17 @@ impl<T: Zero> Zero for NonNegative<T> {
 }
 
 /// A wrapper of greater-than-or-equal-to-one values.
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedZero,
     ToComputedValue,
@@ -114,17 +115,18 @@ impl<T: Zero> Zero for NonNegative<T> {
 pub struct GreaterThanOrEqualToOne<T>(pub T);
 
 /// A wrapper of values between zero and one.
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     Hash,
     MallocSizeOf,
     PartialEq,
     PartialOrd,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedZero,
     ToComputedValue,

--- a/style/values/generics/text.rs
+++ b/style/values/generics/text.rs
@@ -139,17 +139,18 @@ impl<N: ToCss + Zero, I: ToCss + Zero> ToCss for InitialLetter<N, I> {
 ///
 /// https://drafts.csswg.org/css-text-decor-4/
 #[repr(C, u8)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Animate,
     Clone,
     Copy,
     ComputeSquaredDistance,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToAnimatedZero,

--- a/style/values/mod.rs
+++ b/style/values/mod.rs
@@ -463,12 +463,14 @@ pub fn reify_percentage(value: CSSFloat, dest: &mut ThinVec<TypedValue>) -> Resu
 }
 
 /// Convenience void type to disable some properties and values through types.
-#[cfg_attr(feature = "servo", derive(Deserialize, MallocSizeOf, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
+    MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,

--- a/style/values/specified/align.rs
+++ b/style/values/specified/align.rs
@@ -14,9 +14,18 @@ use style_traits::{CssWriter, KeywordsCollectFn, ParseError, SpecifiedValueInfo,
 
 /// Constants shared by multiple CSS Box Alignment properties
 #[derive(
-    Clone, Copy, Debug, Eq, MallocSizeOf, PartialEq, ToComputedValue, ToResolvedValue, ToShmem,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    MallocSizeOf,
+    PartialEq,
+    Serialize,
+    ToComputedValue,
+    ToResolvedValue,
+    ToShmem,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct AlignFlags(u8);
 bitflags! {
@@ -157,16 +166,17 @@ pub enum AxisDirection {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     ToComputedValue,
     ToCss,
     ToResolvedValue,
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 #[typed(todo_derive_fields)]
 pub struct ContentDistribution {
@@ -292,16 +302,17 @@ impl SpecifiedValueInfo for ContentDistribution {
     Copy,
     Debug,
     Deref,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     ToComputedValue,
     ToCss,
     ToResolvedValue,
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 #[typed(todo_derive_fields)]
 pub struct SelfAlignment(pub AlignFlags);
@@ -430,16 +441,17 @@ impl SpecifiedValueInfo for SelfAlignment {
     Copy,
     Debug,
     Deref,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     ToComputedValue,
     ToCss,
     ToResolvedValue,
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 #[typed(todo_derive_fields)]
 pub struct ItemPlacement(pub AlignFlags);
@@ -515,9 +527,20 @@ impl SpecifiedValueInfo for ItemPlacement {
 ///
 /// <https://drafts.csswg.org/css-align/#justify-items-property>
 #[derive(
-    Clone, Copy, Debug, Deref, Eq, MallocSizeOf, PartialEq, ToCss, ToResolvedValue, ToShmem, ToTyped,
+    Clone,
+    Copy,
+    Debug,
+    Deref,
+    Deserialize,
+    Eq,
+    MallocSizeOf,
+    PartialEq,
+    Serialize,
+    ToCss,
+    ToResolvedValue,
+    ToShmem,
+    ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[repr(C)]
 pub struct JustifyItems(pub ItemPlacement);
 

--- a/style/values/specified/border.rs
+++ b/style/values/specified/border.rs
@@ -29,11 +29,11 @@ use thin_vec::ThinVec;
 /// The order here corresponds to the integer values from the border conflict
 /// resolution rules in CSS 2.1 § 17.6.2.1. Higher values override lower values.
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     FromPrimitive,
     MallocSizeOf,
@@ -41,6 +41,7 @@ use thin_vec::ThinVec;
     Parse,
     PartialEq,
     PartialOrd,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -367,15 +368,16 @@ impl Parse for BorderSpacing {
 
 /// A single border-image-repeat keyword.
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,

--- a/style/values/specified/box.rs
+++ b/style/values/specified/box.rs
@@ -811,15 +811,16 @@ impl BaselineSource {
 
 /// https://drafts.csswg.org/css-scroll-snap-1/#snap-axis
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -837,15 +838,16 @@ pub enum ScrollSnapAxis {
 
 /// https://drafts.csswg.org/css-scroll-snap-1/#snap-strictness
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -862,14 +864,15 @@ pub enum ScrollSnapStrictness {
 
 /// https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-type
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToResolvedValue,
@@ -1020,15 +1023,16 @@ impl ToCss for ScrollSnapAlign {
 }
 
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1043,15 +1047,16 @@ pub enum ScrollSnapStop {
 }
 
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1067,15 +1072,16 @@ pub enum OverscrollBehavior {
 }
 
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1402,16 +1408,17 @@ impl Parse for LineClamp {
 }
 
 /// https://drafts.csswg.org/css-contain-2/#content-visibility
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     FromPrimitive,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToAnimatedValue,
     ToComputedValue,
@@ -1576,17 +1583,18 @@ pub type Perspective = GenericPerspective<NonNegativeLength>;
 
 /// https://drafts.csswg.org/css-box/#propdef-float
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     FromPrimitive,
     Hash,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1613,17 +1621,18 @@ impl Float {
 
 /// https://drafts.csswg.org/css2/#propdef-clear
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     FromPrimitive,
     Hash,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1644,16 +1653,17 @@ pub enum Clear {
 
 /// https://drafts.csswg.org/css-ui/#propdef-resize
 #[allow(missing_docs)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     Hash,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToCss,
     ToShmem,

--- a/style/values/specified/font.rs
+++ b/style/values/specified/font.rs
@@ -556,8 +556,10 @@ impl Default for FontSizeKeyword {
     ComputeSquaredDistance,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     ToAnimatedValue,
     ToAnimatedZero,
     ToComputedValue,
@@ -566,7 +568,6 @@ impl Default for FontSizeKeyword {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Serialize, Deserialize))]
 /// Additional information for keyword-derived font sizes.
 pub struct KeywordInfo {
     /// The keyword used
@@ -657,8 +658,7 @@ pub enum FontSize {
 }
 
 /// Specifies a prioritized list of font family names or generic family names.
-#[derive(Clone, Debug, Eq, PartialEq, ToCss, ToShmem, ToTyped)]
-#[cfg_attr(feature = "servo", derive(Hash))]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, ToCss, ToShmem, ToTyped)]
 #[typed(todo_derive_fields)]
 pub enum FontFamily {
     /// List of `font-family`
@@ -1321,10 +1321,13 @@ impl Parse for FontVariantAlternates {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
     Parse,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1332,7 +1335,6 @@ impl Parse for FontVariantAlternates {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 #[css(bitflags(
     single = "normal",
     mixed = "jis78,jis83,jis90,jis04,simplified,traditional,full-width,proportional-width,ruby",
@@ -1391,10 +1393,13 @@ impl FontVariantEastAsian {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
     Parse,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1402,7 +1407,6 @@ impl FontVariantEastAsian {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Hash, Serialize))]
 #[css(bitflags(
     single = "normal,none",
     mixed = "common-ligatures,no-common-ligatures,discretionary-ligatures,no-discretionary-ligatures,historical-ligatures,no-historical-ligatures,contextual,no-contextual",
@@ -1458,10 +1462,13 @@ impl FontVariantLigatures {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
     Parse,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1474,7 +1481,6 @@ impl FontVariantLigatures {
     mixed = "lining-nums,oldstyle-nums,proportional-nums,tabular-nums,diagonal-fractions,stacked-fractions,ordinal,slashed-zero",
     validate_mixed = "Self::validate_mixed_flags",
 ))]
-#[cfg_attr(feature = "servo", derive(Serialize, Deserialize, Hash))]
 #[repr(C)]
 pub struct FontVariantNumeric(u8);
 bitflags! {
@@ -1585,11 +1591,13 @@ impl Parse for FontLanguageOverride {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     Hash,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1597,7 +1605,6 @@ impl Parse for FontLanguageOverride {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 pub enum FontSynthesis {
     /// This attribute may be synthesized if not supported by a face.
     Auto,
@@ -1793,9 +1800,11 @@ impl MetricsOverride {
     Clone,
     Copy,
     Debug,
+    Deserialize,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1803,7 +1812,6 @@ impl MetricsOverride {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Serialize, Deserialize))]
 #[repr(u8)]
 /// How to do font-size scaling.
 pub enum XTextScale {
@@ -1826,8 +1834,12 @@ impl XTextScale {
 #[derive(
     Clone,
     Debug,
+    Deserialize,
+    Eq,
+    Hash,
     MallocSizeOf,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,
@@ -1835,7 +1847,6 @@ impl XTextScale {
     ToShmem,
     ToTyped,
 )]
-#[cfg_attr(feature = "servo", derive(Deserialize, Eq, Hash, Serialize))]
 /// Internal property that reflects the lang attribute
 pub struct XLang(#[css(skip)] pub Atom);
 

--- a/style/values/specified/grid.rs
+++ b/style/values/specified/grid.rs
@@ -138,8 +138,7 @@ pub fn parse_line_names<'i, 't>(
 /// The type of `repeat` function (only used in parsing).
 ///
 /// <https://drafts.csswg.org/css-grid/#typedef-track-repeat>
-#[derive(Clone, Copy, Debug, PartialEq, SpecifiedValueInfo)]
-#[cfg_attr(feature = "servo", derive(MallocSizeOf))]
+#[derive(Clone, Copy, Debug, MallocSizeOf, PartialEq, SpecifiedValueInfo)]
 enum RepeatType {
     /// [`<auto-repeat>`](https://drafts.csswg.org/css-grid/#typedef-auto-repeat)
     Auto,

--- a/style/values/specified/text.rs
+++ b/style/values/specified/text.rs
@@ -1060,15 +1060,16 @@ impl Parse for TextIndent {
 ///
 /// https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink-property
 #[repr(u8)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
 #[derive(
     Clone,
     Copy,
     Debug,
+    Deserialize,
     Eq,
     MallocSizeOf,
     Parse,
     PartialEq,
+    Serialize,
     SpecifiedValueInfo,
     ToComputedValue,
     ToCss,

--- a/style_traits/dom.rs
+++ b/style_traits/dom.rs
@@ -13,8 +13,7 @@
 /// Because the script task's GC does not trace layout, node data cannot be safely stored in layout
 /// data structures. Also, layout code tends to be faster when the DOM is not being accessed, for
 /// locality reasons. Using `OpaqueNode` enforces this invariant.
-#[derive(Clone, Copy, Debug, Eq, Hash, MallocSizeOf, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize))]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, MallocSizeOf, PartialEq, Serialize)]
 pub struct OpaqueNode(pub usize);
 
 impl OpaqueNode {

--- a/style_traits/lib.rs
+++ b/style_traits/lib.rs
@@ -32,8 +32,7 @@ use stylo_atoms::Atom;
 pub enum DevicePixel {}
 
 /// Represents a mobile style pinch zoom factor.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(feature = "servo", derive(Deserialize, Serialize, MallocSizeOf))]
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
 pub struct PinchZoomFactor(f32);
 
 impl PinchZoomFactor {


### PR DESCRIPTION
Already landed upstream: https://phabricator.services.mozilla.com/D311004 (71a8a43642f62f946fcd147e7ac01658e366113e)

Importing it here early to prevent other PRs from adding new Servo-specific derives due to copy-pasting.