### PR TITLE
Stop requiring CI jobs to pass on Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,9 @@ jobs:
     needs:
       - linux-debug
       - linux-release
-      - macos-debug
       - windows-debug
+      # macos-debug is not required, because there are so few runners that waiting for an
+      # available one would take too long.
     steps:
       - name: Success
         if: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
This is a partial revert of #340. Waiting for an available macOS runner frequently takes very long, which makes it annoying when trying to land multiple patches, since they need to also be coordinated with the companion patches in Servo.

So I think it's better to not wait for the macOS job after all. We will still wait for the Linux and Windows ones.