### PR TITLE
Make `text-decoration-color` only generate repaint damage

### DIFF
--- a/style/properties/longhands.toml
+++ b/style/properties/longhands.toml
@@ -2767,7 +2767,7 @@ initial = "computed_value::T::currentcolor()"
 struct = "text"
 ignored_when_colors_disabled = true
 spec = "https://drafts.csswg.org/css-text-decor/#propdef-text-decoration-color"
-servo_restyle_damage = "recalculate_overflow"
+servo_restyle_damage = "repaint"
 affects = "paint"
 
 [text-decoration-inset]


### PR DESCRIPTION
This probably isn't a property that changes frequently in practice, but it seems to me that this ought to only generate `repaint` damage.