### PR TITLE
Derive `Clone` on SourceSize and SourceSizeList

### DIFF
--- a/style/values/specified/source_size_list.rs
+++ b/style/values/specified/source_size_list.rs
@@ -20,7 +20,7 @@ use style_traits::ParseError;
 /// A value for a `<source-size>`:
 ///
 /// https://html.spec.whatwg.org/multipage/#source-size
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceSize {
     condition: QueryCondition,
     value: Length,
@@ -40,7 +40,7 @@ impl Parse for SourceSize {
 /// A value for a `<source-size-list>`:
 ///
 /// https://html.spec.whatwg.org/multipage/#source-size-list
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SourceSizeList {
     source_sizes: Vec<SourceSize>,
     value: Option<Length>,


### PR DESCRIPTION
All members of these structs already derive/implement Clone, so this is trivial. Required for cloning an HTMLLinkElement's source set when constructing LinkProcessingOptions.