### PR TITLE
Adjust restyle damage for clip-path.

### DIFF
--- a/style/properties/longhands.toml
+++ b/style/properties/longhands.toml
@@ -538,7 +538,7 @@ struct = "svg"
 extra_prefixes = ["webkit"]
 spec = "https://drafts.fxtf.org/css-masking-1/#propdef-clip-path"
 affects = "paint"
-servo_restyle_damage = "repaint"
+servo_restyle_damage = "rebuild_stacking_context"
 
 [clip-rule]
 type = "FillRule"


### PR DESCRIPTION
clip-path's calculations in servo occur while building the stacking context. If the value changes, we need to rebuild the stacking context.

https://github.com/servo/servo/pull/47256