### PR TITLE
Implement `animation-composition` for Servo

### DIFF
--- a/style/properties/longhands.toml
+++ b/style/properties/longhands.toml
@@ -2246,7 +2246,6 @@ initial = "computed::AnimationComposition::Replace"
 struct = "ui"
 vector = { need_index = true }
 animation_type = "none"
-servo_pref = "layout.unimplemented"
 spec = "https://drafts.csswg.org/css-animations-2/#animation-composition"
 affects = ""
 

--- a/style/properties/properties.mako.rs
+++ b/style/properties/properties.mako.rs
@@ -1538,6 +1538,7 @@ pub mod style_structs {
             #[cfg(feature = "servo")]
             pub fn animations_equals(&self, other: &Self) -> bool {
                 self.animation_name_iter().eq(other.animation_name_iter()) &&
+                self.animation_composition_iter().eq(other.animation_composition_iter()) &&
                 self.animation_delay_iter().eq(other.animation_delay_iter()) &&
                 self.animation_direction_iter().eq(other.animation_direction_iter()) &&
                 self.animation_duration_iter().eq(other.animation_duration_iter()) &&

--- a/style/servo/animation.rs
+++ b/style/servo/animation.rs
@@ -11,6 +11,7 @@ use crate::context::{CascadeInputs, SharedStyleContext};
 use crate::derives::*;
 use crate::dom::{OpaqueNode, TDocument, TElement, TNode};
 use crate::properties::animated_properties::{AnimationValue, AnimationValueMap};
+use crate::properties::longhands::animation_composition::computed_value::single_value::T as AnimationComposition;
 use crate::properties::longhands::animation_direction::computed_value::single_value::T as AnimationDirection;
 use crate::properties::longhands::animation_fill_mode::computed_value::single_value::T as AnimationFillMode;
 use crate::properties::longhands::animation_play_state::computed_value::single_value::T as AnimationPlayState;
@@ -135,6 +136,7 @@ pub enum KeyframesIterationState {
 struct IntermediateComputedKeyframe {
     declarations: PropertyDeclarationBlock,
     timing_function: Option<TimingFunction>,
+    composition: Option<AnimationComposition>,
     start_percentage: f64,
 }
 
@@ -143,6 +145,7 @@ impl IntermediateComputedKeyframe {
         IntermediateComputedKeyframe {
             declarations: PropertyDeclarationBlock::new(),
             timing_function: None,
+            composition: None,
             start_percentage,
         }
     }
@@ -190,6 +193,12 @@ impl IntermediateComputedKeyframe {
         let guard = &context.guards.author;
         if let Some(timing_function) = step.get_animation_timing_function(&guard) {
             self.timing_function = Some(timing_function.to_computed_value_without_context());
+        }
+
+        // Each keyframe declaration may optionally specify a composite operation,
+        // falling back to the one defined globally for the animation.
+        if let Some(composition) = step.get_animation_composition(&guard) {
+            self.composition = Some(composition);
         }
 
         let block = match step.value {
@@ -295,6 +304,25 @@ struct ComputedKeyframe {
     values: Box<[AnimationValueOrReference]>,
 }
 
+/// Composite a keyframe value with the underlying value according to the
+/// given composite operation.
+///
+/// <https://drafts.csswg.org/web-animations-1/#applying-the-composite-operation>
+fn composite_animation_value(
+    underlying_value: &AnimationValue,
+    keyframe_value: AnimationValue,
+    composition: AnimationComposition,
+) -> AnimationValue {
+    let procedure = match composition {
+        AnimationComposition::Replace => return keyframe_value,
+        AnimationComposition::Add => Procedure::Add,
+        AnimationComposition::Accumulate => Procedure::Accumulate { count: 1 },
+    };
+    underlying_value
+        .animate(&keyframe_value, procedure)
+        .unwrap_or(keyframe_value)
+}
+
 /// Caches the indices of keyframes that declare a specific property.
 ///
 /// While traversing the list of keyframes, this is used to avoid repeatedly
@@ -393,6 +421,7 @@ impl ComputedKeyframe {
         context: &SharedStyleContext,
         base_style: &Arc<ComputedValues>,
         default_timing_function: TimingFunction,
+        default_composition: AnimationComposition,
         resolver: &mut StyleResolverForElement<E>,
         animating_properties: PropertyDeclarationIdSet,
         number_of_animating_properties: usize,
@@ -427,6 +456,7 @@ impl ComputedKeyframe {
                 .timing_function
                 .clone()
                 .unwrap_or_else(|| default_timing_function.clone());
+            let composition = step.composition.unwrap_or(default_composition);
             let step_style = step.resolve_style(element, context, base_style, resolver);
 
             let values: Box<[_]> = {
@@ -444,6 +474,11 @@ impl ComputedKeyframe {
                                 &step_style,
                             )
                             .unwrap();
+                            let animation_value = composite_animation_value(
+                                &animation_values_from_style[property_index],
+                                animation_value,
+                                composition,
+                            );
                             return AnimationValueOrReference::AnimationValue(animation_value);
                         }
 
@@ -1841,6 +1876,7 @@ pub fn maybe_start_animations<E>(
             context,
             new_style,
             style.animation_timing_function_mod(i),
+            style.animation_composition_mod(i),
             resolver,
             animating_properties,
             number_of_animating_properties,

--- a/style/values/animated/transform.rs
+++ b/style/values/animated/transform.rs
@@ -249,18 +249,6 @@ impl From<MatrixDecomposed2D> for Matrix3D {
 }
 
 impl Animate for Matrix {
-    #[cfg(feature = "servo")]
-    fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
-        let this = Matrix3D::from(*self);
-        let other = Matrix3D::from(*other);
-        let this = MatrixDecomposed2D::from(this);
-        let other = MatrixDecomposed2D::from(other);
-        Matrix3D::from(this.animate(&other, procedure)?).into_2d()
-    }
-
-    #[cfg(feature = "gecko")]
-    // Gecko doesn't exactly follow the spec here; we use a different procedure
-    // to match it
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         let this = Matrix3D::from(*self);
         let other = Matrix3D::from(*other);
@@ -836,8 +824,7 @@ fn decompose_3d_matrix(mut matrix: Matrix3D) -> Result<MatrixDecomposed3D, ()> {
  *     [ tan(φ)    1   ]
  */
 
-/// Decompose a 2D matrix for Gecko. This implements the above decomposition algorithm.
-#[cfg(feature = "gecko")]
+/// Decompose a 2D matrix. This implements the above decomposition algorithm.
 fn decompose_2d_matrix(matrix: &Matrix3D) -> Result<MatrixDecomposed3D, ()> {
     // The index is column-major, so the equivalent transform matrix is:
     // | m11 m21  0 m41 |  =>  | m11 m21 | and translate(m41, m42)
@@ -890,28 +877,6 @@ fn decompose_2d_matrix(matrix: &Matrix3D) -> Result<MatrixDecomposed3D, ()> {
 }
 
 impl Animate for Matrix3D {
-    #[cfg(feature = "servo")]
-    fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
-        if self.is_3d() || other.is_3d() {
-            let decomposed_from = decompose_3d_matrix(*self);
-            let decomposed_to = decompose_3d_matrix(*other);
-            match (decomposed_from, decomposed_to) {
-                (Ok(this), Ok(other)) => Ok(Matrix3D::from(this.animate(&other, procedure)?)),
-                // Matrices can be undecomposable due to couple reasons, e.g.,
-                // non-invertible matrices. In this case, we should report Err
-                // here, and let the caller do the fallback procedure.
-                _ => Err(()),
-            }
-        } else {
-            let this = MatrixDecomposed2D::from(*self);
-            let other = MatrixDecomposed2D::from(*other);
-            Ok(Matrix3D::from(this.animate(&other, procedure)?))
-        }
-    }
-
-    #[cfg(feature = "gecko")]
-    // Gecko doesn't exactly follow the spec here; we use a different procedure
-    // to match it
     fn animate(&self, other: &Self, procedure: Procedure) -> Result<Self, ()> {
         let (from, to) = if self.is_3d() || other.is_3d() {
             (decompose_3d_matrix(*self)?, decompose_3d_matrix(*other)?)
@@ -927,21 +892,6 @@ impl Animate for Matrix3D {
 
 impl ComputeSquaredDistance for Matrix3D {
     #[inline]
-    #[cfg(feature = "servo")]
-    fn compute_squared_distance(&self, other: &Self) -> Result<SquaredDistance, ()> {
-        if self.is_3d() || other.is_3d() {
-            let from = decompose_3d_matrix(*self)?;
-            let to = decompose_3d_matrix(*other)?;
-            from.compute_squared_distance(&to)
-        } else {
-            let from = MatrixDecomposed2D::from(*self);
-            let to = MatrixDecomposed2D::from(*other);
-            from.compute_squared_distance(&to)
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "gecko")]
     fn compute_squared_distance(&self, other: &Self) -> Result<SquaredDistance, ()> {
         let (from, to) = if self.is_3d() || other.is_3d() {
             (decompose_3d_matrix(*self)?, decompose_3d_matrix(*other)?)


### PR DESCRIPTION
Changes made:
- Implement the [animation-composition](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/animation-composition) CSS property.
- Shares animation matrix decomposition logic with Gecko (fixes a couple of regressions due to the Servo version of the code not rejecting matrices with a zero determinant)

Implementation is entirely in Stylo.

Servo PR: https://github.com/servo/servo/pull/47405