### PR TITLE
Add prefs for `:has()` and `:nth-child(An+B of S)` selector parsing

### DIFF
--- a/style/servo/selector_parser.rs
+++ b/style/servo/selector_parser.rs
@@ -585,7 +585,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
 
     #[inline]
     fn parse_nth_child_of(&self) -> bool {
-        false
+        static_prefs::pref!("layout.css.nth-child-of.enabled")
     }
 
     #[inline]
@@ -595,7 +595,7 @@ impl<'a, 'i> ::selectors::Parser<'i> for SelectorParser<'a> {
 
     #[inline]
     fn parse_has(&self) -> bool {
-        false
+        static_prefs::pref!("layout.css.has-selector.enabled")
     }
 
     #[inline]

--- a/stylo_static_prefs/preferences.toml
+++ b/stylo_static_prefs/preferences.toml
@@ -19,10 +19,12 @@
 "layout.css.font-tech.enabled" = false
 "layout.css.font-variations.enabled" = true
 "layout.css.gradient-color-interpolation-method.enabled" = true
+"layout.css.has-selector.enabled" = false
 "layout.css.light-dark.images.enabled" = false
 "layout.css.margin-rules.enabled" = false
 "layout.css.marker.restricted" = true
 "layout.css.motion-path-url.enabled" = false
+"layout.css.nth-child-of.enabled" = false
 "layout.css.outline-offset.snapping" = 1
 "layout.css.progress-function.enabled" = false
 "layout.css.properties-and-values.enabled" = true


### PR DESCRIPTION
Servo-only change. Gecko already unconditionally parses these selectors.

This allows support for these features to be implemented in a pref-gated way in Servo and Blitz
(and for those engines to differ as to which they have enabled).