### PR TITLE
Add atoms for cue events

### DIFF
--- a/stylo_atoms/static_atoms.txt
+++ b/stylo_atoms/static_atoms.txt
@@ -45,6 +45,7 @@ compositionend
 compositionstart
 compositionupdate
 controllerchange
+cuechange
 cursive
 dark
 datachannel
@@ -59,7 +60,9 @@ email
 emptied
 end
 ended
+enter
 error
+exit
 fantasy
 fetch
 file


### PR DESCRIPTION
These events are fired for text track cues in track elements.

Part of servo/servo#46288