### PR TITLE
Bump stylo to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 default-members = ["style"]
 
 [workspace.package]
-version = "0.20.0"
+version = "0.21.0"
 
 [workspace.dependencies]
 # in-repo dependencies (separately versioned)
@@ -27,10 +27,10 @@ to_shmem        = { version = "0.5.0",  path = "./to_shmem", features = ["servo"
 to_shmem_derive = { version = "0.1.0",  path = "./to_shmem_derive" }
 
 # in-repo dependencies (main version)
-malloc_size_of  = { version = "0.20.0", path = "./malloc_size_of", package = "stylo_malloc_size_of", features = ["servo"] }
-static_prefs    = { version = "0.20.0", path = "./stylo_static_prefs", package = "stylo_static_prefs" }
-stylo_atoms     = { version = "0.20.0", path = "./stylo_atoms" }
-dom             = { version = "0.20.0", path = "./stylo_dom", package = "stylo_dom" }
-style_traits    = { version = "0.20.0", path = "./style_traits", features = ["servo"], package = "stylo_traits"}
-style_derive    = { version = "0.20.0", path = "./style_derive", package = "stylo_derive"}
-stylo           = { version = "0.20.0", path = "./style" }
+malloc_size_of  = { version = "0.21.0", path = "./malloc_size_of", package = "stylo_malloc_size_of", features = ["servo"] }
+static_prefs    = { version = "0.21.0", path = "./stylo_static_prefs", package = "stylo_static_prefs" }
+stylo_atoms     = { version = "0.21.0", path = "./stylo_atoms" }
+dom             = { version = "0.21.0", path = "./stylo_dom", package = "stylo_dom" }
+style_traits    = { version = "0.21.0", path = "./style_traits", features = ["servo"], package = "stylo_traits"}
+style_derive    = { version = "0.21.0", path = "./style_derive", package = "stylo_derive"}
+stylo           = { version = "0.21.0", path = "./style" }


### PR DESCRIPTION
The actual bump happened on top of b3e6425100df710c7f30125e27a8fb897a709c5e, but we should still increase the version on the `main` branch.